### PR TITLE
Fix Wiz CLI implementation - use binary instead of Docker image

### DIFF
--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -195,25 +195,26 @@ jobs:
           echo "Downloading Wiz CLI..."
           curl -o wizcli https://downloads.wiz.io/wizcli/latest/wizcli-linux-amd64
           chmod +x wizcli
-          sudo mv wizcli /usr/local/bin/
-          wizcli version
+          sudo mv wizcli /usr/local/bin/wiz
+          wiz version
       
       - name: Authenticate with Wiz
         run: |
-          wizcli auth --id "${{ secrets.WIZ_CLIENT_ID }}" --secret "${{ secrets.WIZ_CLIENT_SECRET }}"
+          wiz auth --id "${{ secrets.WIZ_CLIENT_ID }}" --secret "${{ secrets.WIZ_CLIENT_SECRET }}"
       
       - name: Wiz CLI Security Scan
         id: scan
         timeout-minutes: ${{ inputs.scan-timeout-minutes }}
         run: |
           set +e
-          wizcli docker scan scan-target:${{ github.sha }} \
-            --policy "Code Blocking - Vulnerabilities" \
-            --policy "Code Blocking - Secrets" \
-            --policy "Code Blocking - Malware" \
+          wiz docker scan \
+            -i scan-target:${{ github.sha }} \
+            -p "Code Blocking - Vulnerabilities" \
+            -p "Code Blocking - Secrets" \
+            -p "Code Blocking - Malware" \
             --format json \
-            --detailed \
-            --file-hashes-scan > wiz-results.json
+            --file-hashes-scan \
+            --output wiz-results.json
           
           SCAN_EXIT_CODE=$?
           

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -190,25 +190,32 @@ jobs:
           echo "image_size=$IMAGE_SIZE" >> $GITHUB_OUTPUT
           echo "Docker build successful (image size: $IMAGE_SIZE bytes)"
 
+      - name: Install Wiz CLI
+        run: |
+          echo "Downloading Wiz CLI..."
+          curl -o wizcli https://downloads.wiz.io/wizcli/latest/wizcli-linux-amd64
+          chmod +x wizcli
+          sudo mv wizcli /usr/local/bin/
+          wizcli version
+      
+      - name: Authenticate with Wiz
+        run: |
+          wizcli auth --id "${{ secrets.WIZ_CLIENT_ID }}" --secret "${{ secrets.WIZ_CLIENT_SECRET }}"
+      
       - name: Wiz CLI Security Scan
         id: scan
         timeout-minutes: ${{ inputs.scan-timeout-minutes }}
         run: |
           set +e
-          docker run --rm \
-            -v /var/run/docker.sock:/var/run/docker.sock \
-            -e WIZ_CLIENT_ID="${{ secrets.WIZ_CLIENT_ID }}" \
-            -e WIZ_CLIENT_SECRET="${{ secrets.WIZ_CLIENT_SECRET }}" \
-            wiz-io/wizcli:latest \
-            docker scan scan-target:${{ github.sha }} \
+          wizcli docker scan scan-target:${{ github.sha }} \
             --policy "Code Blocking - Vulnerabilities" \
+            --policy "Code Blocking - Secrets" \
             --policy "Code Blocking - Malware" \
             --format json \
             --detailed \
-            --file-hashes-scan 2>&1 > wiz-results.json
+            --file-hashes-scan > wiz-results.json 2>&1
           
           SCAN_EXIT_CODE=$?
-          set -e
           
           echo "scan_exit_code=${SCAN_EXIT_CODE}" >> $GITHUB_OUTPUT
           

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -213,7 +213,8 @@ jobs:
             --policy "Code Blocking - Malware" \
             --format json \
             --detailed \
-            --file-hashes-scan > wiz-results.json 2>&1
+            --file-hashes-scan \
+            --output wiz-results.json
           
           SCAN_EXIT_CODE=$?
           

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -213,8 +213,7 @@ jobs:
             --policy "Code Blocking - Malware" \
             --format json \
             --detailed \
-            --file-hashes-scan \
-            --output wiz-results.json
+            --file-hashes-scan > wiz-results.json
           
           SCAN_EXIT_CODE=$?
           

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -199,7 +199,7 @@ jobs:
             -v /var/run/docker.sock:/var/run/docker.sock \
             -e WIZ_CLIENT_ID="${{ secrets.WIZ_CLIENT_ID }}" \
             -e WIZ_CLIENT_SECRET="${{ secrets.WIZ_CLIENT_SECRET }}" \
-            wizcli/wizcli:latest \
+            wiz-io/wizcli:latest \
             docker scan scan-target:${{ github.sha }} \
             --policy "Code Blocking - Vulnerabilities" \
             --policy "Code Blocking - Malware" \


### PR DESCRIPTION
Replaces non-existent Docker image approach with direct Wiz CLI binary installation.

**Changes:**
- Install Wiz CLI binary from downloads.wiz.io
- Use correct command syntax: `wiz docker scan -i IMAGE -p POLICY`
- Fix authentication and JSON output generation