### PR TITLE
Fix Wiz JSON parsing - handle CLI warning messages

### DIFF
--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -228,25 +228,11 @@ jobs:
             # Check if file is valid JSON
             if ! jq empty wiz-results.json 2>/dev/null; then
               echo "::warning::Wiz output file contains non-JSON content, extracting JSON object"
-              # The Wiz CLI may print warnings before/after the JSON object
-              # Extract the JSON by finding the first { and matching closing }
-              python3 << 'PYEOF' 2>/dev/null
-import sys, json
-try:
-    content = open('wiz-results.json', 'r').read()
-    start = content.find('{')
-    if start == -1:
-        sys.exit(1)
-    content = content[start:]
-    decoder = json.JSONDecoder()
-    obj, idx = decoder.raw_decode(content)
-    with open('wiz-results-clean.json', 'w') as f:
-        json.dump(obj, f)
-except:
-    sys.exit(1)
-PYEOF
+              # The Wiz CLI may print warnings/messages mixed with JSON output
+              # Use grep to find lines containing JSON structure and reconstruct
+              grep -o '{.*}' wiz-results.json | head -1 > wiz-results-clean.json 2>/dev/null || true
               
-              if [ -f "wiz-results-clean.json" ] && jq empty wiz-results-clean.json 2>/dev/null; then
+              if [ -s "wiz-results-clean.json" ] && jq empty wiz-results-clean.json 2>/dev/null; then
                 mv wiz-results-clean.json wiz-results.json
                 echo "Successfully extracted valid JSON object"
               else

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -207,46 +207,28 @@ jobs:
         timeout-minutes: ${{ inputs.scan-timeout-minutes }}
         run: |
           set +e
-          wiz docker scan \
+          
+          # Capture output to variable and file, filtering warnings
+          WIZ_OUTPUT=$(wiz docker scan \
             -i scan-target:${{ github.sha }} \
             -p "Code Blocking - Vulnerabilities" \
             -p "Code Blocking - Secrets" \
             -p "Code Blocking - Malware" \
             --format json \
-            --file-hashes-scan \
-            --output wiz-results.json
+            --file-hashes-scan 2>&1)
           
           SCAN_EXIT_CODE=$?
-          
           echo "scan_exit_code=${SCAN_EXIT_CODE}" >> $GITHUB_OUTPUT
           
-          # Validate JSON output and extract if needed
-          if [ ! -f "wiz-results.json" ]; then
-            echo "::error::Wiz scan did not produce results file"
+          # Extract JSON from output (first complete JSON object)
+          # Wiz CLI may print warnings/messages before or after the JSON
+          echo "$WIZ_OUTPUT" | grep -o '{.*}' | head -1 > wiz-results.json 2>/dev/null || \
             echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json
-          else
-            # Debug: show first and last lines of the file
-            echo "DEBUG: First line of wiz-results.json:"
-            head -c 200 wiz-results.json || true
-            echo ""
-            echo "DEBUG: Last 200 chars:"
-            tail -c 200 wiz-results.json || true
-            echo ""
-            
-            # Check if file is valid JSON
-            if ! jq empty wiz-results.json 2>/dev/null; then
-              echo "::warning::Wiz output file is not valid JSON, attempting to extract"
-              # Try using tr to remove any non-printable characters and extract JSON
-              cat wiz-results.json | tr -cd '[:print:]\n' | grep -o '{.*}' > wiz-results-clean.json 2>/dev/null || true
-              
-              if [ -s "wiz-results-clean.json" ] && jq empty wiz-results-clean.json 2>/dev/null; then
-                mv wiz-results-clean.json wiz-results.json
-                echo "Successfully extracted valid JSON object"
-              else
-                echo "::error::Could not extract valid JSON from Wiz output, creating empty result"
-                echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json
-              fi
-            fi
+          
+          # Validate we got valid JSON
+          if ! jq empty wiz-results.json 2>/dev/null; then
+            echo "::error::Could not extract valid JSON from Wiz CLI output"
+            echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json
           fi
           
           # Parse metrics

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -227,14 +227,30 @@ jobs:
           else
             # Check if file is valid JSON
             if ! jq empty wiz-results.json 2>/dev/null; then
-              echo "::warning::Attempting to extract JSON from Wiz output"
-              # Extract just the JSON object (between first { and last })
-              sed -n '/{/,/^}$/p' wiz-results.json | jq . > wiz-results-clean.json 2>/dev/null || \
-              awk '/^\{/,/^\}$/' wiz-results.json > wiz-results-clean.json 2>/dev/null
+              echo "::warning::Wiz output file contains non-JSON content, extracting JSON object"
+              # The Wiz CLI may print warnings before/after the JSON object
+              # Extract the JSON by finding the first { and matching closing }
+              python3 -c "
+import sys, json
+content = open('wiz-results.json', 'r').read()
+# Find first { and extract from there
+start = content.find('{')
+if start == -1:
+    sys.exit(1)
+content = content[start:]
+# Parse the JSON to find the properly balanced closing }
+try:
+    decoder = json.JSONDecoder()
+    obj, idx = decoder.raw_decode(content)
+    with open('wiz-results-clean.json', 'w') as f:
+        json.dump(obj, f)
+except:
+    sys.exit(1)
+" 2>/dev/null
               
-              if [ -s wiz-results-clean.json ] && jq empty wiz-results-clean.json 2>/dev/null; then
+              if [ -f "wiz-results-clean.json" ] && jq empty wiz-results-clean.json 2>/dev/null; then
                 mv wiz-results-clean.json wiz-results.json
-                echo "Successfully extracted valid JSON"
+                echo "Successfully extracted valid JSON object"
               else
                 echo "::error::Could not extract valid JSON from Wiz output, creating empty result"
                 echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -214,26 +214,29 @@ jobs:
             -p "Code Blocking - Malware" \
             --format json \
             --file-hashes-scan \
-            --output wiz-results.json 2>/dev/null
+            --output wiz-results.json
           
           SCAN_EXIT_CODE=$?
           
           echo "scan_exit_code=${SCAN_EXIT_CODE}" >> $GITHUB_OUTPUT
           
-          # Validate and clean JSON output
+          # Validate JSON output and extract if needed
           if [ ! -f "wiz-results.json" ]; then
             echo "::error::Wiz scan did not produce results file"
             echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json
           else
-            # Try to validate JSON, and if it fails, try to extract JSON object
+            # Check if file is valid JSON
             if ! jq empty wiz-results.json 2>/dev/null; then
-              echo "::warning::Wiz results file contains non-JSON content, attempting to extract JSON"
-              # Try to extract JSON object from file (in case warnings are mixed in)
-              if jq -R -s 'gsub("^[^{]*"; "") | gsub("[^}]*$"; "") | fromjson' wiz-results.json > wiz-results-clean.json 2>/dev/null; then
+              echo "::warning::Attempting to extract JSON from Wiz output"
+              # Extract just the JSON object (between first { and last })
+              sed -n '/{/,/^}$/p' wiz-results.json | jq . > wiz-results-clean.json 2>/dev/null || \
+              awk '/^\{/,/^\}$/' wiz-results.json > wiz-results-clean.json 2>/dev/null
+              
+              if [ -s wiz-results-clean.json ] && jq empty wiz-results-clean.json 2>/dev/null; then
                 mv wiz-results-clean.json wiz-results.json
-                echo "Successfully extracted JSON from results"
+                echo "Successfully extracted valid JSON"
               else
-                echo "::error::Could not extract valid JSON, creating empty result"
+                echo "::error::Could not extract valid JSON from Wiz output, creating empty result"
                 echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json
               fi
             fi

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -225,12 +225,19 @@ jobs:
             echo "::error::Wiz scan did not produce results file"
             echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json
           else
+            # Debug: show first and last lines of the file
+            echo "DEBUG: First line of wiz-results.json:"
+            head -c 200 wiz-results.json || true
+            echo ""
+            echo "DEBUG: Last 200 chars:"
+            tail -c 200 wiz-results.json || true
+            echo ""
+            
             # Check if file is valid JSON
             if ! jq empty wiz-results.json 2>/dev/null; then
-              echo "::warning::Wiz output file contains non-JSON content, extracting JSON object"
-              # The Wiz CLI may print warnings/messages mixed with JSON output
-              # Use grep to find lines containing JSON structure and reconstruct
-              grep -o '{.*}' wiz-results.json | head -1 > wiz-results-clean.json 2>/dev/null || true
+              echo "::warning::Wiz output file is not valid JSON, attempting to extract"
+              # Try using tr to remove any non-printable characters and extract JSON
+              cat wiz-results.json | tr -cd '[:print:]\n' | grep -o '{.*}' > wiz-results-clean.json 2>/dev/null || true
               
               if [ -s "wiz-results-clean.json" ] && jq empty wiz-results-clean.json 2>/dev/null; then
                 mv wiz-results-clean.json wiz-results.json

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -207,27 +207,31 @@ jobs:
         timeout-minutes: ${{ inputs.scan-timeout-minutes }}
         run: |
           set +e
-          
-          # Capture output to variable and file, filtering warnings
-          WIZ_OUTPUT=$(wiz docker scan \
+          wiz docker scan \
             -i scan-target:${{ github.sha }} \
             -p "Code Blocking - Vulnerabilities" \
             -p "Code Blocking - Secrets" \
             -p "Code Blocking - Malware" \
             --format json \
-            --file-hashes-scan 2>&1)
+            --file-hashes-scan \
+            --output wiz-results-raw.json,json
           
           SCAN_EXIT_CODE=$?
           echo "scan_exit_code=${SCAN_EXIT_CODE}" >> $GITHUB_OUTPUT
           
-          # Extract JSON from output (first complete JSON object)
-          # Wiz CLI may print warnings/messages before or after the JSON
-          echo "$WIZ_OUTPUT" | grep -o '{.*}' | head -1 > wiz-results.json 2>/dev/null || \
+          # Wiz CLI may append warning messages after the JSON output in the file
+          # Extract only the first line which contains the valid JSON object
+          if [ -f "wiz-results-raw.json" ]; then
+            head -1 wiz-results-raw.json > wiz-results.json
+            rm wiz-results-raw.json
+          else
+            echo "::error::Wiz scan did not produce results file"
             echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json
+          fi
           
-          # Validate we got valid JSON
+          # Validate JSON
           if ! jq empty wiz-results.json 2>/dev/null; then
-            echo "::error::Could not extract valid JSON from Wiz CLI output"
+            echo "::error::Failed to parse Wiz scan results"
             echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json
           fi
           

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -230,23 +230,21 @@ jobs:
               echo "::warning::Wiz output file contains non-JSON content, extracting JSON object"
               # The Wiz CLI may print warnings before/after the JSON object
               # Extract the JSON by finding the first { and matching closing }
-              python3 -c "
+              python3 << 'PYEOF' 2>/dev/null
 import sys, json
-content = open('wiz-results.json', 'r').read()
-# Find first { and extract from there
-start = content.find('{')
-if start == -1:
-    sys.exit(1)
-content = content[start:]
-# Parse the JSON to find the properly balanced closing }
 try:
+    content = open('wiz-results.json', 'r').read()
+    start = content.find('{')
+    if start == -1:
+        sys.exit(1)
+    content = content[start:]
     decoder = json.JSONDecoder()
     obj, idx = decoder.raw_decode(content)
     with open('wiz-results-clean.json', 'w') as f:
         json.dump(obj, f)
 except:
     sys.exit(1)
-" 2>/dev/null
+PYEOF
               
               if [ -f "wiz-results-clean.json" ] && jq empty wiz-results-clean.json 2>/dev/null; then
                 mv wiz-results-clean.json wiz-results.json

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -214,19 +214,29 @@ jobs:
             -p "Code Blocking - Malware" \
             --format json \
             --file-hashes-scan \
-            --output wiz-results.json
+            --output wiz-results.json 2>/dev/null
           
           SCAN_EXIT_CODE=$?
           
           echo "scan_exit_code=${SCAN_EXIT_CODE}" >> $GITHUB_OUTPUT
           
-          # Validate JSON output
+          # Validate and clean JSON output
           if [ ! -f "wiz-results.json" ]; then
             echo "::error::Wiz scan did not produce results file"
             echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json
-          elif ! jq empty wiz-results.json 2>/dev/null; then
-            echo "::warning::Wiz results file is not valid JSON, creating empty result"
-            echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json
+          else
+            # Try to validate JSON, and if it fails, try to extract JSON object
+            if ! jq empty wiz-results.json 2>/dev/null; then
+              echo "::warning::Wiz results file contains non-JSON content, attempting to extract JSON"
+              # Try to extract JSON object from file (in case warnings are mixed in)
+              if jq -R -s 'gsub("^[^{]*"; "") | gsub("[^}]*$"; "") | fromjson' wiz-results.json > wiz-results-clean.json 2>/dev/null; then
+                mv wiz-results-clean.json wiz-results.json
+                echo "Successfully extracted JSON from results"
+              else
+                echo "::error::Could not extract valid JSON, creating empty result"
+                echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json
+              fi
+            fi
           fi
           
           # Parse metrics


### PR DESCRIPTION
Fixes a bug where Wiz CLI appends warning messages after JSON output, causing vulnerability counts to show as 0.

**Solution:** Use `--output wiz-results-raw.json,json` + `head -1` to extract clean JSON.

**Testing:** Validated on 5 repositories - all now correctly report vulnerability counts.