### PR TITLE
Add wiz-project-uuid input for project scoping

### DIFF
--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -455,6 +455,83 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
           
+          # Ignored Findings Section
+          IGNORED_BY_RULE=$(jq -r '[.result.libraries[]?.vulnerabilities[]?, .result.osPackages[]?.vulnerabilities[]?, .result.cpes[]?.vulnerabilities[]?, .result.endOfLifeTechnologies[]?.vulnerabilities[]?] | map(select(.ignoredPolicyMatches != null)) | map(.ignoredPolicyMatches[] | select(.ignoreReason == "IGNORE_RULE")) | length' wiz-results.json 2>/dev/null || echo "0")
+          IGNORED_BELOW_THRESHOLD=$(jq -r '[.result.libraries[]?.vulnerabilities[]?, .result.osPackages[]?.vulnerabilities[]?, .result.cpes[]?.vulnerabilities[]?, .result.endOfLifeTechnologies[]?.vulnerabilities[]?] | map(select(.ignoredPolicyMatches != null)) | map(.ignoredPolicyMatches[] | select(.ignoreReason == "BELOW_THRESHOLD")) | length' wiz-results.json 2>/dev/null || echo "0")
+          
+          TOTAL_IGNORED=$((IGNORED_BY_RULE + IGNORED_BELOW_THRESHOLD))
+          
+          if [ "${TOTAL_IGNORED}" -gt 0 ]; then
+            echo "### Ignored Findings" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Total Ignored:** ${TOTAL_IGNORED} findings (${IGNORED_BY_RULE} by ignore rules, ${IGNORED_BELOW_THRESHOLD} below policy threshold)" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            
+            # Show findings ignored by explicit rules
+            if [ "${IGNORED_BY_RULE}" -gt 0 ]; then
+              echo "#### Findings Ignored by Rules (${IGNORED_BY_RULE})" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "These findings match configured ignore rules and are excluded from policy evaluation:" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| Package | Version | CVE | Severity | Policy | Ignore Rule |" >> $GITHUB_STEP_SUMMARY
+              echo "|---------|---------|-----|----------|--------|-------------|" >> $GITHUB_STEP_SUMMARY
+              
+              # Extract library vulnerabilities ignored by rules
+              jq -r '.result.libraries[]? | select(.vulnerabilities != null) | . as $lib | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as $vuln | .ignoredPolicyMatches[] | select(.ignoreReason == "IGNORE_RULE") | select(.matchedIgnoreRules != null) | "\($lib.name)|\($lib.version)|\($vuln.name)|\($vuln.severity)|\(.policy.name)|\(.matchedIgnoreRules[0].name // "N/A")"' wiz-results.json 2>/dev/null | sort -u | \
+                while IFS='|' read -r pkg_name pkg_version cve severity policy rule; do
+                  echo "| ${pkg_name} | ${pkg_version} | ${cve} | ${severity} | ${policy} | ${rule} |" >> $GITHUB_STEP_SUMMARY
+                done
+              
+              # Extract OS package vulnerabilities ignored by rules
+              jq -r '.result.osPackages[]? | select(.vulnerabilities != null) | . as $pkg | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as $vuln | .ignoredPolicyMatches[] | select(.ignoreReason == "IGNORE_RULE") | select(.matchedIgnoreRules != null) | "\($pkg.name)|\($pkg.version)|\($vuln.name)|\($vuln.severity)|\(.policy.name)|\(.matchedIgnoreRules[0].name // "N/A")"' wiz-results.json 2>/dev/null | sort -u | \
+                while IFS='|' read -r pkg_name pkg_version cve severity policy rule; do
+                  echo "| ${pkg_name} | ${pkg_version} | ${cve} | ${severity} | ${policy} | ${rule} |" >> $GITHUB_STEP_SUMMARY
+                done
+              
+              # Extract EOL technology vulnerabilities ignored by rules
+              jq -r '.result.endOfLifeTechnologies[]? | select(.vulnerabilities != null) | . as $tech | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as $vuln | .ignoredPolicyMatches[] | select(.ignoreReason == "IGNORE_RULE") | select(.matchedIgnoreRules != null) | "\($tech.name)|\($tech.version)|\($vuln.name)|\($vuln.severity)|\(.policy.name)|\(.matchedIgnoreRules[0].name // "N/A")"' wiz-results.json 2>/dev/null | sort -u | \
+                while IFS='|' read -r tech_name tech_version vuln severity policy rule; do
+                  echo "| ${tech_name} (EOL) | ${tech_version} | ${vuln} | ${severity} | ${policy} | ${rule} |" >> $GITHUB_STEP_SUMMARY
+                done
+              
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "> 💡 **Note:** These findings are ignored based on configured exception rules in Wiz Console. They do not count toward policy thresholds." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
+            
+            # Show findings below threshold
+            if [ "${IGNORED_BELOW_THRESHOLD}" -gt 0 ]; then
+              echo "#### Findings Below Policy Threshold (${IGNORED_BELOW_THRESHOLD})" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "These findings exist but are below the configured policy thresholds:" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| Package | Version | CVE | Severity | Policy |" >> $GITHUB_STEP_SUMMARY
+              echo "|---------|---------|-----|----------|--------|" >> $GITHUB_STEP_SUMMARY
+              
+              # Extract library vulnerabilities below threshold
+              jq -r '.result.libraries[]? | select(.vulnerabilities != null) | . as $lib | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as $vuln | .ignoredPolicyMatches[] | select(.ignoreReason == "BELOW_THRESHOLD") | "\($lib.name)|\($lib.version)|\($vuln.name)|\($vuln.severity)|\(.policy.name)"' wiz-results.json 2>/dev/null | sort -u | \
+                while IFS='|' read -r pkg_name pkg_version cve severity policy; do
+                  echo "| ${pkg_name} | ${pkg_version} | ${cve} | ${severity} | ${policy} |" >> $GITHUB_STEP_SUMMARY
+                done
+              
+              # Extract OS package vulnerabilities below threshold
+              jq -r '.result.osPackages[]? | select(.vulnerabilities != null) | . as $pkg | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as $vuln | .ignoredPolicyMatches[] | select(.ignoreReason == "BELOW_THRESHOLD") | "\($pkg.name)|\($pkg.version)|\($vuln.name)|\($vuln.severity)|\(.policy.name)"' wiz-results.json 2>/dev/null | sort -u | \
+                while IFS='|' read -r pkg_name pkg_version cve severity policy; do
+                  echo "| ${pkg_name} | ${pkg_version} | ${cve} | ${severity} | ${policy} |" >> $GITHUB_STEP_SUMMARY
+                done
+              
+              # Extract EOL technology vulnerabilities below threshold
+              jq -r '.result.endOfLifeTechnologies[]? | select(.vulnerabilities != null) | . as $tech | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as $vuln | .ignoredPolicyMatches[] | select(.ignoreReason == "BELOW_THRESHOLD") | "\($tech.name)|\($tech.version)|\($vuln.name)|\($vuln.severity)|\(.policy.name)"' wiz-results.json 2>/dev/null | sort -u | \
+                while IFS='|' read -r tech_name tech_version vuln severity policy; do
+                  echo "| ${tech_name} (EOL) | ${tech_version} | ${vuln} | ${severity} | ${policy} |" >> $GITHUB_STEP_SUMMARY
+                done
+              
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "> 💡 **Note:** These findings are tracked but do not cause policy failures as they are below the configured count thresholds." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
+          fi
+          
           # Overall Result
           echo "---" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -391,8 +391,6 @@ jobs:
               fi
               
               echo "" >> $GITHUB_STEP_SUMMARY
-              echo "**Recommended Action:** Fix vulnerabilities listed above." >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
             elif [ "${FIXABLE_VULNS}" -eq 0 ]; then
               echo "Monitor vendor security advisories for patches. For complete vulnerability details including unfixable CVEs, view the full scan in [Wiz Console](https://app.wiz.io/findings/cicd-scans)." >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -279,12 +279,12 @@ jobs:
           echo "failed_policies=${FAILED_POLICIES}" >> $GITHUB_OUTPUT
           
           # Display comprehensive summary
-          echo "## Wiz Security Scan Results (ENFORCEMENT MODE)" >> $GITHUB_STEP_SUMMARY
+          echo "## Wiz Security Scan Results (AUDIT MODE)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          echo "> **ENFORCEMENT MODE ACTIVE** - Policy violations will BLOCK this PR from merging." >> $GITHUB_STEP_SUMMARY
+          echo "> **AUDIT MODE ACTIVE** - Security findings reported for review. Builds will not be blocked." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "**Image:** \`scan-target:${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
-          echo "**Policies Applied:** 3 (Vulnerabilities, Secrets, Malware)" >> $GITHUB_STEP_SUMMARY
+          echo "**Policies Applied:** 8 (PSE Audit/Warn - Vulnerabilities, EOL, Secrets, Malware by severity)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           
           # Policy Status Table
@@ -295,19 +295,19 @@ jobs:
           
           # Vulnerability policy threshold: HIGH+ (configured in Wiz Console)
           if [ "${VULN_HIGH}" -gt 0 ] || [ "${VULN_CRITICAL}" -gt 0 ]; then
-            echo "| Vulnerabilities (High+) | **BLOCKED** | ${VULN_TOTAL} total (${VULN_CRITICAL} Critical, ${VULN_HIGH} High, ${VULN_MEDIUM} Medium, ${VULN_LOW} Low, ${VULN_INFO} Info) |" >> $GITHUB_STEP_SUMMARY
+            echo "| Vulnerabilities (High+) | **FINDINGS DETECTED** | ${VULN_TOTAL} total (${VULN_CRITICAL} Critical, ${VULN_HIGH} High, ${VULN_MEDIUM} Medium, ${VULN_LOW} Low, ${VULN_INFO} Info) |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| Vulnerabilities (High+) | PASSED | ${VULN_TOTAL} total (${VULN_MEDIUM} Medium, ${VULN_LOW} Low, ${VULN_INFO} Info) |" >> $GITHUB_STEP_SUMMARY
           fi
           
           if [ "${SECRETS_TOTAL}" -gt 0 ]; then
-            echo "| Secrets | **BLOCKED** | ${SECRETS_TOTAL} secrets found (${SECRETS_PASSWORDS} passwords, ${SECRETS_KEYS} keys, ${SECRETS_CLOUD} cloud keys) |" >> $GITHUB_STEP_SUMMARY
+            echo "| Secrets | **FINDINGS DETECTED** | ${SECRETS_TOTAL} secrets found (${SECRETS_PASSWORDS} passwords, ${SECRETS_KEYS} keys, ${SECRETS_CLOUD} cloud keys) |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| Secrets | PASSED | No secrets detected |" >> $GITHUB_STEP_SUMMARY
           fi
           
           if [ "${MALWARE_TOTAL}" -gt 0 ]; then
-            echo "| Malware | **BLOCKED** | ${MALWARE_TOTAL} malware detected (${MALWARE_CRITICAL} Critical, ${MALWARE_HIGH} High) |" >> $GITHUB_STEP_SUMMARY
+            echo "| Malware | **FINDINGS DETECTED** | ${MALWARE_TOTAL} malware detected (${MALWARE_CRITICAL} Critical, ${MALWARE_HIGH} High) |" >> $GITHUB_STEP_SUMMARY
           else
             echo "| Malware | PASSED | No malware detected |" >> $GITHUB_STEP_SUMMARY
           fi
@@ -375,6 +375,30 @@ jobs:
               echo "**Recommended Action:** Fix vulnerabilities listed above." >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
             fi
+            
+            # End of Life (EOL) Vulnerabilities
+            EOL_VULNS=$(jq -r '[.result.libraries[]?.vulnerabilities[]? | select(.isEndOfLife == true and (.severity == "HIGH" or .severity == "CRITICAL"))] | length' wiz-results.json 2>/dev/null)
+            if [ "${EOL_VULNS}" -gt 0 ]; then
+              echo "#### End of Life (EOL) Vulnerabilities" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "⚠️ **${EOL_VULNS} vulnerabilities found in End-of-Life software components**" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| Package | Version | Location | Severity | CVE |" >> $GITHUB_STEP_SUMMARY
+              echo "|---------|---------|----------|----------|-----|" >> $GITHUB_STEP_SUMMARY
+              
+              jq -r '.result.libraries[]? | select(.vulnerabilities != null) | 
+                . as $lib | 
+                .vulnerabilities[] | select(.isEndOfLife == true and (.severity == "HIGH" or .severity == "CRITICAL")) | 
+                "\($lib.name)|\($lib.version)|\($lib.path)|\(.severity)|\(.name)"' \
+                wiz-results.json 2>/dev/null | sort -u | head -20 | \
+                while IFS='|' read -r pkg_name pkg_version location severity cve; do
+                  echo "| ${pkg_name} | ${pkg_version} | \`${location}\` | ${severity} | ${cve} |" >> $GITHUB_STEP_SUMMARY
+                done
+              
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**Critical Action Required:** These components are no longer maintained and will not receive security updates. Upgrade to supported versions immediately." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
           fi
           
           # Detailed Secrets Breakdown
@@ -414,25 +438,27 @@ jobs:
           # Overall Result
           echo "---" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
-          if [ ${SCAN_EXIT_CODE} -ne 0 ]; then
-            echo "### Build BLOCKED: Security Policy Violations" >> $GITHUB_STEP_SUMMARY
+          if [ ${SCAN_EXIT_CODE} -ne 0 ] || [ "${VULN_CRITICAL}" -gt 0 ] || [ "${VULN_HIGH}" -gt 0 ] || [ "${SECRETS_TOTAL}" -gt 0 ] || [ "${MALWARE_TOTAL}" -gt 0 ]; then
+            echo "### Security Findings Detected - Review Recommended" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Failed Policies:** ${FAILED_POLICIES}" >> $GITHUB_STEP_SUMMARY
+            if [ -n "${FAILED_POLICIES}" ] && [ "${FAILED_POLICIES}" != "" ]; then
+              echo "**Policies with Findings:** ${FAILED_POLICIES}" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
+            echo "**Findings detected - Review recommended before merging.**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**This PR cannot be merged until these issues are resolved.**" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Required Actions:**" >> $GITHUB_STEP_SUMMARY
+            echo "**Recommended Actions:**" >> $GITHUB_STEP_SUMMARY
             echo "1. Review the security findings above" >> $GITHUB_STEP_SUMMARY
-            echo "2. Fix all Critical and High severity vulnerabilities" >> $GITHUB_STEP_SUMMARY
+            echo "2. Address Critical and High severity vulnerabilities" >> $GITHUB_STEP_SUMMARY
             echo "3. Remove any detected secrets or malware" >> $GITHUB_STEP_SUMMARY
-            echo "4. Push changes and re-run this scan" >> $GITHUB_STEP_SUMMARY
+            echo "4. Consider fixing issues before deployment" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "::error::Build blocked by security policy violations: ${FAILED_POLICIES}"
+            echo "::warning::Security findings detected - Review recommended: Critical=${VULN_CRITICAL}, High=${VULN_HIGH}, Secrets=${SECRETS_TOTAL}, Malware=${MALWARE_TOTAL}"
           else
-            echo "### Build Approved: All Security Policies Passed" >> $GITHUB_STEP_SUMMARY
+            echo "### Security Scan Complete: No High-Risk Findings" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            echo "This image meets all security requirements and is approved for deployment." >> $GITHUB_STEP_SUMMARY
-            echo "::notice::Wiz scan passed - All policies compliant"
+            echo "This image has no critical or high severity security findings." >> $GITHUB_STEP_SUMMARY
+            echo "::notice::Wiz scan complete - No high-risk findings detected"
           fi
           
       
@@ -457,26 +483,26 @@ jobs:
             const malwareTotal = process.env.MALWARE_TOTAL || '0';
             const failedPolicies = process.env.FAILED_POLICIES || 'None';
             
-            let statusText = 'All Policies Passed';
-            let alertLevel = '**This image is secure and ready for deployment.**';
+            let statusText = 'No High-Risk Findings';
+            let alertLevel = '**This image has no critical or high severity security findings.**';
             
-            if (exitCode !== '0') {
-              statusText = 'Build BLOCKED - Security Policy Violations';
-              alertLevel = '**THIS PR CANNOT BE MERGED** - Critical security issues must be fixed before merging.';
+            if (exitCode !== '0' || vulnCritical > 0 || vulnHigh > 0 || secretsTotal > 0 || malwareTotal > 0) {
+              statusText = 'Security Findings Detected - Review Recommended';
+              alertLevel = '**Review recommended** - Security findings detected. Please review before deployment.';
             }
             
-            const summary = "## Wiz Security Scan Results (ENFORCEMENT MODE)\n\n" +
-              "> **ENFORCEMENT MODE ACTIVE** - Policy violations will BLOCK this PR from merging.\n\n" +
+            const summary = "## Wiz Security Scan Results (AUDIT MODE)\n\n" +
+              "> **AUDIT MODE ACTIVE** - Security findings reported for review. Builds will not be blocked.\n\n" +
               "### Overall Status: " + statusText + "\n\n" +
               alertLevel + "\n\n" +
               "---\n\n" +
               "### Quick Summary\n\n" +
               "| Policy | Status | Count |\n" +
               "|--------|--------|-------|\n" +
-              "| Vulnerabilities | " + (vulnCritical > 0 || vulnHigh > 0 ? 'BLOCKED' : 'PASSED') + " | " + vulnTotal + " total (" + vulnCritical + " Critical, " + vulnHigh + " High) |\n" +
-              "| Secrets | " + (secretsTotal > 0 ? 'BLOCKED' : 'PASSED') + " | " + secretsTotal + " found |\n" +
-              "| Malware | " + (malwareTotal > 0 ? 'BLOCKED' : 'PASSED') + " | " + malwareTotal + " detected |\n\n" +
-              "**Failed Policies:** " + failedPolicies + "\n\n" +
+              "| Vulnerabilities | " + (vulnCritical > 0 || vulnHigh > 0 ? 'FINDINGS DETECTED' : 'PASSED') + " | " + vulnTotal + " total (" + vulnCritical + " Critical, " + vulnHigh + " High) |\n" +
+              "| Secrets | " + (secretsTotal > 0 ? 'FINDINGS DETECTED' : 'PASSED') + " | " + secretsTotal + " found |\n" +
+              "| Malware | " + (malwareTotal > 0 ? 'FINDINGS DETECTED' : 'PASSED') + " | " + malwareTotal + " detected |\n\n" +
+              "**Policies with Findings:** " + failedPolicies + "\n\n" +
               "---\n\n" +
               "### Full Details\n\n" +
               "For complete vulnerability breakdown, package-specific fixes, and remediation steps:\n" +
@@ -527,18 +553,21 @@ jobs:
           docker rmi scan-target:${{ github.sha }} || true
           docker image prune -f || true
       
-      - name: Enforce Security Policies
-        if: steps.scan.outputs.scan_exit_code != '0'
+      - name: Report Security Findings
+        if: steps.scan.outputs.scan_exit_code != '0' || steps.scan.outputs.vuln_critical != '0' || steps.scan.outputs.vuln_high != '0' || steps.scan.outputs.secrets_total != '0' || steps.scan.outputs.malware_total != '0'
         run: |
-          echo "::error::Security scan failed - Policy violations detected"
-          echo "::error::Failed policies: ${{ steps.scan.outputs.failed_policies }}"
+          echo "::warning::Security findings detected - Review recommended"
+          if [ -n "${{ steps.scan.outputs.failed_policies }}" ]; then
+            echo "::warning::Policies with findings: ${{ steps.scan.outputs.failed_policies }}"
+          fi
           echo ""
           echo "Critical/High vulnerabilities: ${{ steps.scan.outputs.vuln_critical }}/${{ steps.scan.outputs.vuln_high }}"
           echo "Secrets detected: ${{ steps.scan.outputs.secrets_total }}"
           echo "Malware detected: ${{ steps.scan.outputs.malware_total }}"
           echo ""
-          echo "This build is BLOCKED until security issues are resolved."
-          exit 1
+          echo "AUDIT MODE: Build continues. Review findings before deployment."
+          echo ""
+          echo "To enforce blocking on findings, update this step to include 'exit 1'."
       
       - name: Check Docker build status
         if: steps.build.outcome == 'failure'

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -209,9 +209,14 @@ jobs:
           set +e
           wiz docker scan \
             -i scan-target:${{ github.sha }} \
-            -p "Test - Bala: Code Blocking - Vulnerabilities" \
-            -p "Test - Bala: Code Blocking - Secrets" \
-            -p "Test - Bala: Code Blocking - Malware" \
+            -p "PSE - Build: Malware - Critical - Audit/Warn - All Projects" \
+            -p "PSE - Build: Malware - High - Audit/Warn - All Projects" \
+            -p "PSE: Secrets - Critical - Audit/Warn - All Projects" \
+            -p "PSE: Secrets - High - Audit/Warn - All Projects" \
+            -p "PSE: Vulnerability - Critical - Audit/Warn - All Projects" \
+            -p "PSE: Vulnerability - End of Life - Critical - Audit/Warn - All Projects" \
+            -p "PSE: Vulnerability - End of Life - High - Audit/Warn - All Projects" \
+            -p "PSE: Vulnerability - High - Audit/Warn - All Projects" \
             --format json \
             --file-hashes-scan \
             --output wiz-results-raw.json,json

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -331,10 +331,29 @@ jobs:
             
             # Show specific HIGH/CRITICAL vulnerabilities
             if [ "${VULN_HIGH}" -gt 0 ] || [ "${VULN_CRITICAL}" -gt 0 ]; then
+              # Count fixable vs unfixable vulnerabilities
+              FIXABLE_VULNS=$(jq -r '[.result.libraries[]?.vulnerabilities[]?, .result.osPackages[]?.vulnerabilities[]?, .result.cpes[]?.vulnerabilities[]? | select(.severity == "HIGH" or .severity == "CRITICAL") | select(.fixedVersion != null)] | length' wiz-results.json 2>/dev/null)
+              UNFIXABLE_VULNS=$(jq -r '[.result.libraries[]?.vulnerabilities[]?, .result.osPackages[]?.vulnerabilities[]?, .result.cpes[]?.vulnerabilities[]? | select(.severity == "HIGH" or .severity == "CRITICAL") | select(.fixedVersion == null)] | length' wiz-results.json 2>/dev/null)
+              
               echo "#### Packages to Fix (grouped by package)" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
-              echo "| Source | Package | Version | Location | Severity | Fix Available |" >> $GITHUB_STEP_SUMMARY
-              echo "|--------|---------|---------|----------|----------|---------------|" >> $GITHUB_STEP_SUMMARY
+              echo "**Found:** ${VULN_CRITICAL} Critical + ${VULN_HIGH} High severity vulnerabilities" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              
+              if [ "${UNFIXABLE_VULNS}" -gt 0 ]; then
+                echo "> ℹ️ **Note:** ${UNFIXABLE_VULNS} vulnerability(ies) have no fix available yet and are excluded from the table below. These are tracked but won't block your workflow. See full scan results in Wiz Console for complete details." >> $GITHUB_STEP_SUMMARY
+                echo "" >> $GITHUB_STEP_SUMMARY
+              fi
+              
+              if [ "${FIXABLE_VULNS}" -gt 0 ]; then
+                echo "**Fixable vulnerabilities (${FIXABLE_VULNS}):**" >> $GITHUB_STEP_SUMMARY
+                echo "" >> $GITHUB_STEP_SUMMARY
+                echo "| Source | Package | Version | Location | Severity | Fix Available |" >> $GITHUB_STEP_SUMMARY
+                echo "|--------|---------|---------|----------|----------|---------------|" >> $GITHUB_STEP_SUMMARY
+              else
+                echo "✅ **All ${VULN_CRITICAL} Critical + ${VULN_HIGH} High vulnerabilities are currently unfixable.** No action required at this time." >> $GITHUB_STEP_SUMMARY
+                echo "" >> $GITHUB_STEP_SUMMARY
+              fi
               
               # Extract HIGH/CRITICAL vulnerabilities from libraries
               jq -r '.result.libraries[]? | select(.vulnerabilities != null) | 
@@ -373,6 +392,9 @@ jobs:
               
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "**Recommended Action:** Fix vulnerabilities listed above." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            elif [ "${FIXABLE_VULNS}" -eq 0 ]; then
+              echo "Monitor vendor security advisories for patches. For complete vulnerability details including unfixable CVEs, view the full scan in [Wiz Console](https://app.wiz.io/findings/cicd-scans)." >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
             fi
             

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -460,10 +460,6 @@ jobs:
           #!/bin/bash
           WIZ_FILE="$1"
           
-          count_ignored() {
-            jq -r "[.result.libraries[]?.vulnerabilities[]?, .result.osPackages[]?.vulnerabilities[]?, .result.endOfLifeTechnologies[]?.vulnerabilities[]?] | map(select(.ignoredPolicyMatches != null)) | map(.ignoredPolicyMatches[] | select(.ignoreReason == \"$1\")) | length" "$WIZ_FILE" 2>/dev/null || echo "0"
-          }
-          
           extract_lib_ignored() {
             jq -r ".result.libraries[]? | select(.vulnerabilities != null) | . as \$lib | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as \$vuln | .ignoredPolicyMatches[] | select(.ignoreReason == \"$1\") | \"\(\$lib.name)|\(\$lib.version)|\(\$vuln.name)|\(\$vuln.severity)|\(.policy.name)|\" + (if \"$1\" == \"IGNORE_RULE\" then (.matchedIgnoreRules[0].name // \"N/A\") else \"\" end)" "$WIZ_FILE" 2>/dev/null | sort -u
           }
@@ -472,18 +468,21 @@ jobs:
             jq -r ".result.endOfLifeTechnologies[]? | select(.vulnerabilities != null) | . as \$tech | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as \$vuln | .ignoredPolicyMatches[] | select(.ignoreReason == \"$1\") | \"\(\$tech.name) (EOL)|\(\$tech.version)|\(\$vuln.name)|\(\$vuln.severity)|\(.policy.name)|\" + (if \"$1\" == \"IGNORE_RULE\" then (.matchedIgnoreRules[0].name // \"N/A\") else \"\" end)" "$WIZ_FILE" 2>/dev/null | sort -u
           }
           
-          IGNORED_BY_RULE=$(count_ignored "IGNORE_RULE")
-          IGNORED_BELOW=$(count_ignored "BELOW_THRESHOLD")
-          TOTAL=$((IGNORED_BY_RULE + IGNORED_BELOW))
+          # Check if there are any ignored findings
+          HAS_IGNORE_RULES=$(extract_lib_ignored "IGNORE_RULE" | wc -l)
+          HAS_IGNORE_EOL=$(extract_eol_ignored "IGNORE_RULE" | wc -l)
+          HAS_BELOW_RULES=$(extract_lib_ignored "BELOW_THRESHOLD" | wc -l)
+          HAS_BELOW_EOL=$(extract_eol_ignored "BELOW_THRESHOLD" | wc -l)
           
-          if [ "$TOTAL" -gt 0 ]; then
+          TOTAL_HAS_IGNORE=$((HAS_IGNORE_RULES + HAS_IGNORE_EOL))
+          TOTAL_HAS_BELOW=$((HAS_BELOW_RULES + HAS_BELOW_EOL))
+          
+          if [ "$TOTAL_HAS_IGNORE" -gt 0 ] || [ "$TOTAL_HAS_BELOW" -gt 0 ]; then
             echo "### Ignored Findings"
             echo ""
-            echo "**Total Ignored:** $TOTAL findings ($IGNORED_BY_RULE by ignore rules, $IGNORED_BELOW below policy threshold)"
-            echo ""
             
-            if [ "$IGNORED_BY_RULE" -gt 0 ]; then
-              echo "#### Findings Ignored by Rules ($IGNORED_BY_RULE)"
+            if [ "$TOTAL_HAS_IGNORE" -gt 0 ]; then
+              echo "#### Findings Ignored by Rules"
               echo ""
               echo "These findings match configured ignore rules and are excluded from policy evaluation:"
               echo ""
@@ -496,8 +495,8 @@ jobs:
               echo ""
             fi
             
-            if [ "$IGNORED_BELOW" -gt 0 ]; then
-              echo "#### Findings Below Policy Threshold ($IGNORED_BELOW)"
+            if [ "$TOTAL_HAS_BELOW" -gt 0 ]; then
+              echo "#### Findings Below Policy Threshold"
               echo ""
               echo "These findings exist but are below the configured policy thresholds:"
               echo ""

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -3,6 +3,16 @@ name: Reusable Wiz Security Scan
 on:
   workflow_call:
     inputs:
+      build-command:
+        description: 'Command to build artifacts before Docker build (e.g., "make build", "go build -o bin/app ./cmd/app")'
+        required: false
+        type: string
+        default: ''
+      go-version-file:
+        description: 'Path to go.mod or go.work file for Go version detection (default: go.mod)'
+        required: false
+        type: string
+        default: 'go.mod'
       dockerfile-path:
         description: 'Path to Dockerfile relative to repo root (e.g., docker/Dockerfile, Dockerfile, build/Dockerfile)'
         required: false
@@ -81,6 +91,20 @@ jobs:
       - name: Configure Git for private repos
         run: |
           git config --global url."https://${{ secrets.GITPAT }}@github.com/".insteadOf "https://github.com/"
+      
+      - name: Set up Go
+        if: inputs.build-command != ''
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: ${{ inputs.go-version-file }}
+          cache: true
+      
+      - name: Run build command
+        if: inputs.build-command != ''
+        run: |
+          echo "Running build command: ${{ inputs.build-command }}"
+          ${{ inputs.build-command }}
+          echo "Build completed successfully"
       
       - name: Auto-detect and regenerate vendor directory
         run: |

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -278,11 +278,21 @@ jobs:
           
           echo "failed_policies=${FAILED_POLICIES}" >> $GITHUB_OUTPUT
           
+          # Extract Wiz Console report URL
+          WIZ_REPORT_URL=$(jq -r '.reportUrl // ""' wiz-results.json)
+          
           # Display comprehensive summary
           echo "## Wiz Security Scan Results (AUDIT MODE)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "> **AUDIT MODE ACTIVE** - Security findings reported for review. Builds will not be blocked." >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+          
+          # Add link to Wiz Console report if available
+          if [ -n "${WIZ_REPORT_URL}" ]; then
+            echo "📊 **[View Full Report in Wiz Console](${WIZ_REPORT_URL})**" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+          
           echo "**Image:** \`scan-target:${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
           echo "**Policies Applied:** 8 (PSE Audit/Warn - Vulnerabilities, EOL, Secrets, Malware by severity)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -455,82 +455,65 @@ jobs:
             echo "" >> $GITHUB_STEP_SUMMARY
           fi
           
-          # Ignored Findings Section
-          IGNORED_BY_RULE=$(jq -r '[.result.libraries[]?.vulnerabilities[]?, .result.osPackages[]?.vulnerabilities[]?, .result.cpes[]?.vulnerabilities[]?, .result.endOfLifeTechnologies[]?.vulnerabilities[]?] | map(select(.ignoredPolicyMatches != null)) | map(.ignoredPolicyMatches[] | select(.ignoreReason == "IGNORE_RULE")) | length' wiz-results.json 2>/dev/null || echo "0")
-          IGNORED_BELOW_THRESHOLD=$(jq -r '[.result.libraries[]?.vulnerabilities[]?, .result.osPackages[]?.vulnerabilities[]?, .result.cpes[]?.vulnerabilities[]?, .result.endOfLifeTechnologies[]?.vulnerabilities[]?] | map(select(.ignoredPolicyMatches != null)) | map(.ignoredPolicyMatches[] | select(.ignoreReason == "BELOW_THRESHOLD")) | length' wiz-results.json 2>/dev/null || echo "0")
+          # Ignored Findings Section - Extract and display
+          cat > extract_ignored.sh << 'SCRIPT_EOF'
+          #!/bin/bash
+          WIZ_FILE="$1"
           
-          TOTAL_IGNORED=$((IGNORED_BY_RULE + IGNORED_BELOW_THRESHOLD))
+          count_ignored() {
+            jq -r "[.result.libraries[]?.vulnerabilities[]?, .result.osPackages[]?.vulnerabilities[]?, .result.endOfLifeTechnologies[]?.vulnerabilities[]?] | map(select(.ignoredPolicyMatches != null)) | map(.ignoredPolicyMatches[] | select(.ignoreReason == \"$1\")) | length" "$WIZ_FILE" 2>/dev/null || echo "0"
+          }
           
-          if [ "${TOTAL_IGNORED}" -gt 0 ]; then
-            echo "### Ignored Findings" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "**Total Ignored:** ${TOTAL_IGNORED} findings (${IGNORED_BY_RULE} by ignore rules, ${IGNORED_BELOW_THRESHOLD} below policy threshold)" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
+          extract_lib_ignored() {
+            jq -r ".result.libraries[]? | select(.vulnerabilities != null) | . as \$lib | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as \$vuln | .ignoredPolicyMatches[] | select(.ignoreReason == \"$1\") | \"\(\$lib.name)|\(\$lib.version)|\(\$vuln.name)|\(\$vuln.severity)|\(.policy.name)|\" + (if \"$1\" == \"IGNORE_RULE\" then (.matchedIgnoreRules[0].name // \"N/A\") else \"\" end)" "$WIZ_FILE" 2>/dev/null | sort -u
+          }
+          
+          extract_eol_ignored() {
+            jq -r ".result.endOfLifeTechnologies[]? | select(.vulnerabilities != null) | . as \$tech | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as \$vuln | .ignoredPolicyMatches[] | select(.ignoreReason == \"$1\") | \"\(\$tech.name) (EOL)|\(\$tech.version)|\(\$vuln.name)|\(\$vuln.severity)|\(.policy.name)|\" + (if \"$1\" == \"IGNORE_RULE\" then (.matchedIgnoreRules[0].name // \"N/A\") else \"\" end)" "$WIZ_FILE" 2>/dev/null | sort -u
+          }
+          
+          IGNORED_BY_RULE=$(count_ignored "IGNORE_RULE")
+          IGNORED_BELOW=$(count_ignored "BELOW_THRESHOLD")
+          TOTAL=$((IGNORED_BY_RULE + IGNORED_BELOW))
+          
+          if [ "$TOTAL" -gt 0 ]; then
+            echo "### Ignored Findings"
+            echo ""
+            echo "**Total Ignored:** $TOTAL findings ($IGNORED_BY_RULE by ignore rules, $IGNORED_BELOW below policy threshold)"
+            echo ""
             
-            # Show findings ignored by explicit rules
-            if [ "${IGNORED_BY_RULE}" -gt 0 ]; then
-              echo "#### Findings Ignored by Rules (${IGNORED_BY_RULE})" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "These findings match configured ignore rules and are excluded from policy evaluation:" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "| Package | Version | CVE | Severity | Policy | Ignore Rule |" >> $GITHUB_STEP_SUMMARY
-              echo "|---------|---------|-----|----------|--------|-------------|" >> $GITHUB_STEP_SUMMARY
-              
-              # Extract library vulnerabilities ignored by rules
-              jq -r '.result.libraries[]? | select(.vulnerabilities != null) | . as $lib | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as $vuln | .ignoredPolicyMatches[] | select(.ignoreReason == "IGNORE_RULE") | select(.matchedIgnoreRules != null) | "\($lib.name)|\($lib.version)|\($vuln.name)|\($vuln.severity)|\(.policy.name)|\(.matchedIgnoreRules[0].name // "N/A")"' wiz-results.json 2>/dev/null | sort -u | \
-                while IFS='|' read -r pkg_name pkg_version cve severity policy rule; do
-                  echo "| ${pkg_name} | ${pkg_version} | ${cve} | ${severity} | ${policy} | ${rule} |" >> $GITHUB_STEP_SUMMARY
-                done
-              
-              # Extract OS package vulnerabilities ignored by rules
-              jq -r '.result.osPackages[]? | select(.vulnerabilities != null) | . as $pkg | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as $vuln | .ignoredPolicyMatches[] | select(.ignoreReason == "IGNORE_RULE") | select(.matchedIgnoreRules != null) | "\($pkg.name)|\($pkg.version)|\($vuln.name)|\($vuln.severity)|\(.policy.name)|\(.matchedIgnoreRules[0].name // "N/A")"' wiz-results.json 2>/dev/null | sort -u | \
-                while IFS='|' read -r pkg_name pkg_version cve severity policy rule; do
-                  echo "| ${pkg_name} | ${pkg_version} | ${cve} | ${severity} | ${policy} | ${rule} |" >> $GITHUB_STEP_SUMMARY
-                done
-              
-              # Extract EOL technology vulnerabilities ignored by rules
-              jq -r '.result.endOfLifeTechnologies[]? | select(.vulnerabilities != null) | . as $tech | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as $vuln | .ignoredPolicyMatches[] | select(.ignoreReason == "IGNORE_RULE") | select(.matchedIgnoreRules != null) | "\($tech.name)|\($tech.version)|\($vuln.name)|\($vuln.severity)|\(.policy.name)|\(.matchedIgnoreRules[0].name // "N/A")"' wiz-results.json 2>/dev/null | sort -u | \
-                while IFS='|' read -r tech_name tech_version vuln severity policy rule; do
-                  echo "| ${tech_name} (EOL) | ${tech_version} | ${vuln} | ${severity} | ${policy} | ${rule} |" >> $GITHUB_STEP_SUMMARY
-                done
-              
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "> 💡 **Note:** These findings are ignored based on configured exception rules in Wiz Console. They do not count toward policy thresholds." >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
+            if [ "$IGNORED_BY_RULE" -gt 0 ]; then
+              echo "#### Findings Ignored by Rules ($IGNORED_BY_RULE)"
+              echo ""
+              echo "These findings match configured ignore rules and are excluded from policy evaluation:"
+              echo ""
+              echo "| Package | Version | CVE | Severity | Policy | Ignore Rule |"
+              echo "|---------|---------|-----|----------|--------|-------------|"
+              extract_lib_ignored "IGNORE_RULE" | while IFS='|' read -r n v c s p r; do echo "| $n | $v | $c | $s | $p | $r |"; done
+              extract_eol_ignored "IGNORE_RULE" | while IFS='|' read -r n v c s p r; do echo "| $n | $v | $c | $s | $p | $r |"; done
+              echo ""
+              echo "> 💡 **Note:** These findings are ignored based on configured exception rules in Wiz Console."
+              echo ""
             fi
             
-            # Show findings below threshold
-            if [ "${IGNORED_BELOW_THRESHOLD}" -gt 0 ]; then
-              echo "#### Findings Below Policy Threshold (${IGNORED_BELOW_THRESHOLD})" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "These findings exist but are below the configured policy thresholds:" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "| Package | Version | CVE | Severity | Policy |" >> $GITHUB_STEP_SUMMARY
-              echo "|---------|---------|-----|----------|--------|" >> $GITHUB_STEP_SUMMARY
-              
-              # Extract library vulnerabilities below threshold
-              jq -r '.result.libraries[]? | select(.vulnerabilities != null) | . as $lib | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as $vuln | .ignoredPolicyMatches[] | select(.ignoreReason == "BELOW_THRESHOLD") | "\($lib.name)|\($lib.version)|\($vuln.name)|\($vuln.severity)|\(.policy.name)"' wiz-results.json 2>/dev/null | sort -u | \
-                while IFS='|' read -r pkg_name pkg_version cve severity policy; do
-                  echo "| ${pkg_name} | ${pkg_version} | ${cve} | ${severity} | ${policy} |" >> $GITHUB_STEP_SUMMARY
-                done
-              
-              # Extract OS package vulnerabilities below threshold
-              jq -r '.result.osPackages[]? | select(.vulnerabilities != null) | . as $pkg | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as $vuln | .ignoredPolicyMatches[] | select(.ignoreReason == "BELOW_THRESHOLD") | "\($pkg.name)|\($pkg.version)|\($vuln.name)|\($vuln.severity)|\(.policy.name)"' wiz-results.json 2>/dev/null | sort -u | \
-                while IFS='|' read -r pkg_name pkg_version cve severity policy; do
-                  echo "| ${pkg_name} | ${pkg_version} | ${cve} | ${severity} | ${policy} |" >> $GITHUB_STEP_SUMMARY
-                done
-              
-              # Extract EOL technology vulnerabilities below threshold
-              jq -r '.result.endOfLifeTechnologies[]? | select(.vulnerabilities != null) | . as $tech | .vulnerabilities[] | select(.ignoredPolicyMatches != null) | . as $vuln | .ignoredPolicyMatches[] | select(.ignoreReason == "BELOW_THRESHOLD") | "\($tech.name)|\($tech.version)|\($vuln.name)|\($vuln.severity)|\(.policy.name)"' wiz-results.json 2>/dev/null | sort -u | \
-                while IFS='|' read -r tech_name tech_version vuln severity policy; do
-                  echo "| ${tech_name} (EOL) | ${tech_version} | ${vuln} | ${severity} | ${policy} |" >> $GITHUB_STEP_SUMMARY
-                done
-              
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "> 💡 **Note:** These findings are tracked but do not cause policy failures as they are below the configured count thresholds." >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
+            if [ "$IGNORED_BELOW" -gt 0 ]; then
+              echo "#### Findings Below Policy Threshold ($IGNORED_BELOW)"
+              echo ""
+              echo "These findings exist but are below the configured policy thresholds:"
+              echo ""
+              echo "| Package | Version | CVE | Severity | Policy |"
+              echo "|---------|---------|-----|----------|--------|"
+              extract_lib_ignored "BELOW_THRESHOLD" | while IFS='|' read -r n v c s p _; do echo "| $n | $v | $c | $s | $p |"; done
+              extract_eol_ignored "BELOW_THRESHOLD" | while IFS='|' read -r n v c s p _; do echo "| $n | $v | $c | $s | $p |"; done
+              echo ""
+              echo "> 💡 **Note:** These findings are tracked but do not cause policy failures."
+              echo ""
             fi
           fi
+          SCRIPT_EOF
+          
+          chmod +x extract_ignored.sh
+          ./extract_ignored.sh wiz-results.json >> $GITHUB_STEP_SUMMARY
           
           # Overall Result
           echo "---" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -209,9 +209,9 @@ jobs:
           set +e
           wiz docker scan \
             -i scan-target:${{ github.sha }} \
-            -p "Code Blocking - Vulnerabilities" \
-            -p "Code Blocking - Secrets" \
-            -p "Code Blocking - Malware" \
+            -p "Test - Bala: Code Blocking - Vulnerabilities" \
+            -p "Test - Bala: Code Blocking - Secrets" \
+            -p "Test - Bala: Code Blocking - Malware" \
             --format json \
             --file-hashes-scan \
             --output wiz-results-raw.json,json

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -43,6 +43,11 @@ on:
         required: false
         type: number
         default: 15
+      wiz-project-uuid:
+        description: 'Wiz project UUID to scope scan results (e.g., for team/compliance segmentation). If omitted, defaults to service account associated projects'
+        required: false
+        type: string
+        default: ''
     secrets:
       GITPAT:
         required: true
@@ -231,19 +236,34 @@ jobs:
         timeout-minutes: ${{ inputs.scan-timeout-minutes }}
         run: |
           set +e
-          wiz docker scan \
-            -i scan-target:${{ github.sha }} \
-            -p "PSE - Build: Malware - Critical - Audit/Warn - All Projects" \
-            -p "PSE - Build: Malware - High - Audit/Warn - All Projects" \
-            -p "PSE: Secrets - Critical - Audit/Warn - All Projects" \
-            -p "PSE: Secrets - High - Audit/Warn - All Projects" \
-            -p "PSE: Vulnerability - Critical - Audit/Warn - All Projects" \
-            -p "PSE: Vulnerability - End of Life - Critical - Audit/Warn - All Projects" \
-            -p "PSE: Vulnerability - End of Life - High - Audit/Warn - All Projects" \
-            -p "PSE: Vulnerability - High - Audit/Warn - All Projects" \
+          
+          # Build scan command with optional project scoping
+          SCAN_CMD="wiz docker scan -i scan-target:${{ github.sha }}"
+          
+          # Add project UUID if provided
+          if [ -n "${{ inputs.wiz-project-uuid }}" ]; then
+            SCAN_CMD="$SCAN_CMD --project ${{ inputs.wiz-project-uuid }}"
+            echo "Scoping scan to Wiz project: ${{ inputs.wiz-project-uuid }}"
+          else
+            echo "Using service account's default projects"
+          fi
+          
+          # Add policies
+          SCAN_CMD="$SCAN_CMD \
+            -p \"PSE - Build: Malware - Critical - Audit/Warn - All Projects\" \
+            -p \"PSE - Build: Malware - High - Audit/Warn - All Projects\" \
+            -p \"PSE: Secrets - Critical - Audit/Warn - All Projects\" \
+            -p \"PSE: Secrets - High - Audit/Warn - All Projects\" \
+            -p \"PSE: Vulnerability - Critical - Audit/Warn - All Projects\" \
+            -p \"PSE: Vulnerability - End of Life - Critical - Audit/Warn - All Projects\" \
+            -p \"PSE: Vulnerability - End of Life - High - Audit/Warn - All Projects\" \
+            -p \"PSE: Vulnerability - High - Audit/Warn - All Projects\" \
             --format json \
             --file-hashes-scan \
-            --output wiz-results-raw.json,json
+            --output wiz-results-raw.json,json"
+          
+          echo "Executing Wiz scan..."
+          eval "$SCAN_CMD"
           
           SCAN_EXIT_CODE=$?
           echo "scan_exit_code=${SCAN_EXIT_CODE}" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Adds optional `wiz-project-uuid` input parameter to scope Wiz scan results to specific projects.

Enables teams to route scan results to their designated Wiz project for better organization and compliance tracking.