### PR TITLE
upgrade Wiz CLI from v0.x to v1.x

### DIFF
--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -198,14 +198,14 @@ jobs:
       - name: Install Wiz CLI
         run: |
           echo "Downloading Wiz CLI..."
-          curl -o wizcli https://downloads.wiz.io/wizcli/latest/wizcli-linux-amd64
+          curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64
           chmod +x wizcli
-          sudo mv wizcli /usr/local/bin/wiz
-          wiz version
+          sudo mv wizcli /usr/local/bin/wizcli
+          wizcli version
       
       - name: Authenticate with Wiz
         run: |
-          wiz auth --id "${{ secrets.WIZ_CLIENT_ID }}" --secret "${{ secrets.WIZ_CLIENT_SECRET }}"
+          wizcli auth --id "${{ secrets.WIZ_CLIENT_ID }}" --secret "${{ secrets.WIZ_CLIENT_SECRET }}" --assist-migration
       
       - name: Wiz CLI Security Scan
         id: scan
@@ -214,29 +214,20 @@ jobs:
           set +e
           
           # Build scan command with optional project scoping
-          SCAN_CMD="wiz docker scan -i scan-target:${{ github.sha }}"
+          SCAN_CMD="wizcli scan container-image scan-target:${{ github.sha }} --assist-migration --by-policy-hits AUDIT"
           
           # Add project UUID if provided
           if [ -n "${{ inputs.wiz-project-uuid }}" ]; then
-            SCAN_CMD="$SCAN_CMD --project ${{ inputs.wiz-project-uuid }}"
+            SCAN_CMD="$SCAN_CMD --projects ${{ inputs.wiz-project-uuid }}"
             echo "Scoping scan to Wiz project: ${{ inputs.wiz-project-uuid }}"
           else
             echo "Using service account's default projects"
           fi
           
-          # Add policies
+          # Add policies (v1.x uses comma-separated list)
           SCAN_CMD="$SCAN_CMD \
-            -p \"PSE - Build: Malware - Critical - Audit/Warn - All Projects\" \
-            -p \"PSE - Build: Malware - High - Audit/Warn - All Projects\" \
-            -p \"PSE: Secrets - Critical - Audit/Warn - All Projects\" \
-            -p \"PSE: Secrets - High - Audit/Warn - All Projects\" \
-            -p \"PSE: Vulnerability - Critical - Audit/Warn - All Projects\" \
-            -p \"PSE: Vulnerability - End of Life - Critical - Audit/Warn - All Projects\" \
-            -p \"PSE: Vulnerability - End of Life - High - Audit/Warn - All Projects\" \
-            -p \"PSE: Vulnerability - High - Audit/Warn - All Projects\" \
-            --format json \
-            --file-hashes-scan \
-            --output wiz-results-raw.json,json"
+            -p \"PSE - Build: Malware - Critical - Audit/Warn - All Projects,PSE - Build: Malware - High - Audit/Warn - All Projects,PSE: Secrets - Critical - Audit/Warn - All Projects,PSE: Secrets - High - Audit/Warn - All Projects,PSE: Vulnerability - Critical - Audit/Warn - All Projects,PSE: Vulnerability - End of Life - Critical - Audit/Warn - All Projects,PSE: Vulnerability - End of Life - High - Audit/Warn - All Projects,PSE: Vulnerability - High - Audit/Warn - All Projects\" \
+            --json-output-file wiz-results.json"
           
           echo "Executing Wiz scan..."
           eval "$SCAN_CMD"
@@ -244,12 +235,8 @@ jobs:
           SCAN_EXIT_CODE=$?
           echo "scan_exit_code=${SCAN_EXIT_CODE}" >> $GITHUB_OUTPUT
           
-          # Wiz CLI may append warning messages after the JSON output in the file
-          # Extract only the first line which contains the valid JSON object
-          if [ -f "wiz-results-raw.json" ]; then
-            head -1 wiz-results-raw.json > wiz-results.json
-            rm wiz-results-raw.json
-          else
+          # Verify scan produced results
+          if [ ! -f "wiz-results.json" ]; then
             echo "::error::Wiz scan did not produce results file"
             echo '{"result":{"analytics":{"vulnerabilities":{},"secrets":{},"malware":{}}}}' > wiz-results.json
           fi

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -205,7 +205,7 @@ jobs:
       
       - name: Authenticate with Wiz
         run: |
-          wizcli auth --id "${{ secrets.WIZ_CLIENT_ID }}" --secret "${{ secrets.WIZ_CLIENT_SECRET }}" --assist-migration
+          wizcli auth --id "${{ secrets.WIZ_CLIENT_ID }}" --secret "${{ secrets.WIZ_CLIENT_SECRET }}"
       
       - name: Wiz CLI Security Scan
         id: scan


### PR DESCRIPTION
## Summary
Upgrades the reusable Wiz security scan workflow from Wiz CLI v0.x to v1.x.

## Changes
- **Download URL**: `wizcli/latest` → `v1/wizcli/latest`
- **Binary name**: `wiz` → `wizcli`
- **Scan command**: `wiz docker scan -i` → `wizcli scan container-image`
- **Scan flags**: Added `--assist-migration` (backward compat with existing service accounts) and `--by-policy-hits AUDIT` (ensures full vulnerability data in JSON output)
- **Project flag**: `--project` → `--projects` (v1.x rename)
- **Policies**: Separate `-p` flags → single comma-separated `-p`
- **Output**: `--format json --file-hashes-scan --output file,json` → `--json-output-file` (v1.x writes clean JSON directly, removes `head -1` workaround)

## Testing
- Tested locally with wizcli v1.42.0 against `alpine:latest` and `golang:1.19`
- Verified JSON schema backward compatibility (`result.analytics`, `osPackages`, `libraries`, `cpes`, `secrets`, `malwares`, `failedPolicyMatches`, `reportUrl` all present)
- End-to-end test via `ddi-dns-last-queried-updater` workflow dispatch on `test/wizcli-v1-upgrade` branch — **all steps passed**: https://github.com/Infoblox-CTO/ddi-dns-last-queried-updater/actions/runs/24473428558