### PR TITLE
feat: Add pre-build, GITPAT build-arg, and disk cleanup inputs to Wiz reusable workflow

### DIFF
--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -115,6 +115,10 @@ jobs:
           echo "Disk space after cleanup:"
           df -h /
       
+      # NOTE: Auto-detect (elif vendor/ + go.mod) was removed because it forced
+      # 'go mod tidy && go mod vendor' on every Go repo with committed vendor/,
+      # breaking builds where GITPAT lacks access to all private dependencies.
+      # Repos needing vendor regen should explicitly pass enable-vendor-regen: true.
       - name: Auto-detect and regenerate vendor directory
         run: |
           VENDOR_REGEN_NEEDED=false
@@ -123,10 +127,8 @@ jobs:
           if [ "${{ inputs.enable-vendor-regen }}" = "true" ]; then
             VENDOR_REGEN_NEEDED=true
             echo "Vendor regeneration explicitly enabled via input"
-          # Auto-detect if vendor directory exists and might be stale
-          elif [ -d "vendor" ] && [ -f "go.mod" ]; then
-            VENDOR_REGEN_NEEDED=true
-            echo "Detected vendor/ directory - will regenerate to ensure compatibility"
+          else
+            echo "Vendor regeneration not requested — using existing vendor/ as-is"
           fi
           
           if [ "$VENDOR_REGEN_NEEDED" = "true" ]; then

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -38,6 +38,21 @@ on:
         required: false
         type: string
         default: ''
+      enable-gitpat-build-arg:
+        description: 'Pass GITPAT as a Docker build argument (GITHUB_PAT) for Dockerfiles that clone private repos during build'
+        required: false
+        type: boolean
+        default: false
+      pre-build-command:
+        description: 'Shell command to run before Docker build (e.g., "make download" to generate build artifacts needed by Dockerfile)'
+        required: false
+        type: string
+        default: ''
+      enable-disk-cleanup:
+        description: 'Free disk space before scan by removing unused SDKs (.NET, Android, etc.). Enable for large images (>2GB) that cause "no space left on device" errors.'
+        required: false
+        type: boolean
+        default: false
     secrets:
       GITPAT:
         required: true
@@ -87,6 +102,19 @@ jobs:
         run: |
           git config --global url."https://${{ secrets.GITPAT }}@github.com/".insteadOf "https://github.com/"
       
+      - name: Free disk space
+        if: ${{ inputs.enable-disk-cleanup }}
+        run: |
+          echo "Freeing disk space for large image scanning..."
+          df -h /
+          sudo rm -rf /usr/share/dotnet || true
+          sudo rm -rf /usr/local/lib/android || true
+          sudo rm -rf /opt/ghcrunner || true
+          sudo rm -rf /opt/hostedtoolcache || true
+          sudo docker system prune -af || true
+          echo "Disk space after cleanup:"
+          df -h /
+      
       - name: Auto-detect and regenerate vendor directory
         run: |
           VENDOR_REGEN_NEEDED=false
@@ -110,6 +138,13 @@ jobs:
           else
             echo "No vendor regeneration needed"
           fi
+      
+      - name: Run pre-build command
+        if: ${{ inputs.pre-build-command != '' }}
+        run: |
+          echo "Running pre-build command: ${{ inputs.pre-build-command }}"
+          ${{ inputs.pre-build-command }}
+          echo "Pre-build command completed successfully"
       
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -162,6 +197,12 @@ jobs:
                 echo "  --build-arg $line"
               fi
             done <<< "${{ inputs.docker-build-args }}"
+          fi
+          
+          # Add GITPAT as GITHUB_PAT build arg if enabled
+          if [ "${{ inputs.enable-gitpat-build-arg }}" = "true" ]; then
+            echo "Adding GITHUB_PAT build argument from GITPAT secret..."
+            BUILD_CMD="$BUILD_CMD --build-arg GITHUB_PAT=${{ secrets.GITPAT }}"
           fi
           
           # Add build secrets if provided


### PR DESCRIPTION
## Summary

Adds three new **opt-in** inputs to the Wiz security scan reusable workflow to support repos with special Docker build requirements, and **fixes a critical bug in vendor directory auto-detection** that breaks all Go repos with committed vendor directories.

## Changes

### 1. `enable-gitpat-build-arg` (boolean, default: `false`)
- Passes `GITPAT` secret as `--build-arg GITHUB_PAT` during Docker build
- **Use case:** Dockerfiles that clone private repos during build (e.g., `ngp.onprem.logger`)
- Uses existing `secrets.GITPAT` — no new secrets needed

### 2. `pre-build-command` (string, default: `''`)
- Runs a shell command before `docker build`
- **Use case:** Repos that generate build artifacts needed by Dockerfile (e.g., `k3s.manager` needs `make k3s-download`)
- Conditional: skipped when input is empty

### 3. `enable-disk-cleanup` (boolean, default: `false`)
- Frees ~20GB disk space by removing unused SDKs (.NET, Android, etc.)
- **Use case:** Large images (>2GB) that cause `no space left on device` during Wiz scan (e.g., `atlas.onprem.troubleshooting`)
- Removes: `.NET SDK`, `Android SDK`, `hosted tool cache`, `unused Docker images`

### 4. Fix: Remove auto-detect vendor regeneration (BUG FIX)
- Removed the `elif [ -d "vendor" ] && [ -f "go.mod" ]` clause that **forced** `go mod tidy && go mod vendor` on every Go repo with a committed `vendor/` directory
- This broke repos where GITPAT lacks access to all private dependencies or where shallow clones cause pseudo-version failures
- Repos needing vendor regen can still opt-in with `enable-vendor-regen: true`

## Bug Fix Details

### Problem
The auto-detect logic always triggered for Go repos with `vendor/` + `go.mod`, making the `enable-vendor-regen` input meaningless:

```bash
# BEFORE (buggy):
if [ "${{ inputs.enable-vendor-regen }}" = "true" ]; then
    VENDOR_REGEN_NEEDED=true
elif [ -d "vendor" ] && [ -f "go.mod" ]; then
    VENDOR_REGEN_NEEDED=true  # Always triggers — defeats opt-in design
fi
```

### Root Cause of Failures
- `go mod tidy` requires network access to ALL private dependencies
- `GITPAT` does not have access to every private repo (e.g., `atlas.realm.resolver`)
- Shallow clones cause `invalid pseudo-version` errors during `go mod vendor`

### Fix
```bash
# AFTER (fixed):
if [ "${{ inputs.enable-vendor-regen }}" = "true" ]; then
    VENDOR_REGEN_NEEDED=true
else
    echo "Vendor regeneration not requested — using existing vendor/ as-is"
fi
```

### Affected PRs (all blocked by this bug)
- [atlas.onprem.scheduler PR #1047](https://github.com/Infoblox-CTO/atlas.onprem.scheduler/pull/1047)
- [atlas.onprem.scout PR #192](https://github.com/Infoblox-CTO/atlas.onprem.scout/pull/192)
- [atlas.onprem.host.controller PR #167](https://github.com/Infoblox-CTO/atlas.onprem.host.controller/pull/167)

## Impact
- **All inputs default to disabled** — zero impact on existing callers
- Each step has an `if:` condition — skipped when input is not set
- No changes to existing secrets, steps, or behavior
- Repos with committed vendor now build correctly without forced regen

## Backward Compatibility
- Repos without vendor: unaffected
- Repos with vendor + `-mod=vendor` builds: now work correctly (no forced regen)
- Repos that need vendor regen: pass `enable-vendor-regen: true` explicitly

## Related PRs (waiting for this to merge)
- ngp.onprem.logger PR #213 — will add `enable-gitpat-build-arg: true`
- k3s.manager PR #370 — will add `pre-build-command: 'make k3s-download'`
- atlas.onprem.troubleshooting PR #271 — will add `enable-disk-cleanup: true`
- atlas.onprem.scheduler PR #1047 — blocked by vendor bug (fixed here)
- atlas.onprem.scout PR #192 — blocked by vendor bug (fixed here)
- atlas.onprem.host.controller PR #167 — blocked by vendor bug (fixed here)
