### PR TITLE
feat: add reusable IaC & Directory scan workflow with detailed summary

### DIFF
--- a/.github/workflows/wiz-iac-scan-reusable.yaml
+++ b/.github/workflows/wiz-iac-scan-reusable.yaml
@@ -35,6 +35,13 @@ jobs:
       pull-requests: write
 
     steps:
+      - name: Validate required secrets
+        run: |
+          if [ -z "${{ secrets.WIZ_CLIENT_ID }}" ] || [ -z "${{ secrets.WIZ_CLIENT_SECRET }}" ]; then
+            echo "::error::Missing required secrets: WIZ_CLIENT_ID and WIZ_CLIENT_SECRET must be configured"
+            exit 1
+          fi
+
       - name: Checkout code
         uses: actions/checkout@v4
 
@@ -99,6 +106,7 @@ jobs:
           echo "### IaC Scan (Dockerfile, Helm, Kubernetes Misconfigurations)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
 
+          IAC_HIGH=0
           if [ -f "iac-results.json" ] && jq empty iac-results.json 2>/dev/null; then
             IAC_FINDINGS=$(jq -r '[.result.iacFindings[]?] | length' iac-results.json 2>/dev/null || echo "0")
             IAC_HIGH=$(jq -r '[.result.iacFindings[]? | select(.severity == "HIGH" or .severity == "CRITICAL")] | length' iac-results.json 2>/dev/null || echo "0")
@@ -128,10 +136,14 @@ jobs:
           fi
 
           # ═══════════════════════════════════════════════════════════
-          # Directory Scan — Source-Level Library Vulnerabilities
+          # Directory Scan — Libraries, Secrets & Sensitive Data
           # ═══════════════════════════════════════════════════════════
-          echo "### Directory Scan (Source-Level Library Vulnerabilities)" >> $GITHUB_STEP_SUMMARY
+          echo "### Directory Scan (Source-Level Libraries, Secrets & Sensitive Data)" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
+
+          DIR_CRITICAL=0
+          DIR_HIGH=0
+          DIR_SECRETS=0
 
           if [ -f "dir-results.json" ] && jq empty dir-results.json 2>/dev/null; then
             DIR_VULN_TOTAL=$(jq -r '[.result.libraries[]?.vulnerabilities[]?] | length' dir-results.json 2>/dev/null || echo "0")
@@ -145,7 +157,6 @@ jobs:
               echo "**Found:** ${DIR_VULN_TOTAL} vulnerabilities (${DIR_CRITICAL} Critical, ${DIR_HIGH} High, ${DIR_MEDIUM} Medium, ${DIR_LOW} Low/Info)" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
 
-              # Show Critical + High + Medium in the table
               SHOW_VULNS=$(jq -r '[.result.libraries[]?.vulnerabilities[]? | select(.severity == "CRITICAL" or .severity == "HIGH" or .severity == "MEDIUM")] | length' dir-results.json 2>/dev/null || echo "0")
 
               if [ "${SHOW_VULNS}" -gt 0 ]; then
@@ -173,12 +184,10 @@ jobs:
               echo "" >> $GITHUB_STEP_SUMMARY
             fi
 
-            # Secrets findings from directory scan
+            # Secrets & Sensitive Data findings
             DIR_SECRETS=$(jq -r '[.result.secrets[]?] | length' dir-results.json 2>/dev/null || echo "0")
             if [ "${DIR_SECRETS}" -gt 0 ]; then
-              echo "### ⚠️ Secrets Detection" >> $GITHUB_STEP_SUMMARY
-              echo "" >> $GITHUB_STEP_SUMMARY
-              echo "**${DIR_SECRETS} secret(s) detected in source files.**" >> $GITHUB_STEP_SUMMARY
+              echo "⚠️ **${DIR_SECRETS} secret(s) detected in source files:**" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "| Type | Location | Description |" >> $GITHUB_STEP_SUMMARY
               echo "|------|----------|-------------|" >> $GITHUB_STEP_SUMMARY
@@ -187,8 +196,38 @@ jobs:
                   echo "| ${type} | \`${location}\` | ${desc} |" >> $GITHUB_STEP_SUMMARY
                 done
               echo "" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "✅ No secrets or sensitive data found." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
             fi
           else
             echo "⚠️ Directory scan results not available (JSON missing or invalid)." >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # ═══════════════════════════════════════════════════════════
+          # Overall Result
+          # ═══════════════════════════════════════════════════════════
+          echo "---" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ "${IAC_HIGH}" -gt 0 ] || [ "${DIR_HIGH}" -gt 0 ] || [ "${DIR_CRITICAL}" -gt 0 ] || [ "${DIR_SECRETS}" -gt 0 ]; then
+            echo "### Findings Detected - Review Recommended" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "**Recommended Actions:**" >> $GITHUB_STEP_SUMMARY
+            echo "1. Review the IaC misconfigurations and library vulnerabilities above" >> $GITHUB_STEP_SUMMARY
+            echo "2. Address Critical and High severity findings" >> $GITHUB_STEP_SUMMARY
+            if [ "${DIR_SECRETS}" -gt 0 ]; then
+              echo "3. Remove any detected secrets from source files" >> $GITHUB_STEP_SUMMARY
+              echo "4. Check the **Docker Image Scan** to confirm which are in the production binary" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "3. Check the **Docker Image Scan** to confirm which are in the production binary" >> $GITHUB_STEP_SUMMARY
+            fi
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "::warning::IaC/Directory scan findings detected - Review recommended"
+          else
+            echo "### Scan Complete: No High-Risk Findings" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            echo "No critical or high severity misconfigurations, library vulnerabilities, or secrets detected in source files." >> $GITHUB_STEP_SUMMARY
+            echo "::notice::IaC & Directory scan complete - No high-risk findings"
           fi

--- a/.github/workflows/wiz-iac-scan-reusable.yaml
+++ b/.github/workflows/wiz-iac-scan-reusable.yaml
@@ -1,0 +1,194 @@
+name: Reusable Wiz IaC & Directory Scan
+
+on:
+  workflow_call:
+    inputs:
+      scan-path:
+        description: 'Path to scan relative to repo root (default: repository root)'
+        required: false
+        type: string
+        default: '.'
+      iac-types:
+        description: 'IaC types to scan (comma-separated: Dockerfile,Kubernetes,Helm,Terraform)'
+        required: false
+        type: string
+        default: 'Dockerfile,Kubernetes'
+      scan-timeout-minutes:
+        description: 'Timeout for Wiz scans in minutes'
+        required: false
+        type: number
+        default: 10
+    secrets:
+      WIZ_CLIENT_ID:
+        required: true
+        description: 'Wiz service account client ID'
+      WIZ_CLIENT_SECRET:
+        required: true
+        description: 'Wiz service account client secret'
+
+jobs:
+  iac-dir-scan:
+    name: Wiz IaC & Directory Scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Install Wiz CLI
+        run: |
+          curl -o wizcli https://downloads.wiz.io/v1/wizcli/latest/wizcli-linux-amd64
+          chmod +x wizcli
+          sudo mv wizcli /usr/local/bin/wizcli
+          wizcli version
+
+      - name: Authenticate with Wiz
+        run: |
+          wizcli auth --id "${{ secrets.WIZ_CLIENT_ID }}" --secret "${{ secrets.WIZ_CLIENT_SECRET }}"
+
+      - name: IaC Scan (Dockerfile, Helm, Kubernetes manifests)
+        id: iac-scan
+        continue-on-error: true
+        timeout-minutes: ${{ inputs.scan-timeout-minutes }}
+        run: |
+          wizcli iac scan \
+            --path ${{ inputs.scan-path }} \
+            --types ${{ inputs.iac-types }} \
+            --format human \
+            --output iac-results.json,json
+
+      - name: Directory Scan (libraries, secrets, sensitive data)
+        id: dir-scan
+        continue-on-error: true
+        timeout-minutes: ${{ inputs.scan-timeout-minutes }}
+        run: |
+          wizcli dir scan \
+            --path ${{ inputs.scan-path }} \
+            --secrets \
+            --format human \
+            --output dir-results.json,json
+
+      - name: Upload IaC scan results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wiz-iac-scan-results-${{ github.sha }}
+          path: iac-results.json
+          retention-days: 90
+
+      - name: Upload directory scan results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: wiz-dir-scan-results-${{ github.sha }}
+          path: dir-results.json
+          retention-days: 90
+
+      - name: Scan Summary
+        if: always()
+        run: |
+          echo "## IaC & Directory Scan Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          # ═══════════════════════════════════════════════════════════
+          # IaC Scan — Dockerfile/Helm/K8s Misconfigurations
+          # ═══════════════════════════════════════════════════════════
+          echo "### IaC Scan (Dockerfile, Helm, Kubernetes Misconfigurations)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ -f "iac-results.json" ] && jq empty iac-results.json 2>/dev/null; then
+            IAC_FINDINGS=$(jq -r '[.result.iacFindings[]?] | length' iac-results.json 2>/dev/null || echo "0")
+            IAC_HIGH=$(jq -r '[.result.iacFindings[]? | select(.severity == "HIGH" or .severity == "CRITICAL")] | length' iac-results.json 2>/dev/null || echo "0")
+
+            if [ "${IAC_HIGH}" -gt 0 ]; then
+              echo "**${IAC_HIGH} High/Critical misconfiguration(s) found** (${IAC_FINDINGS} total findings)" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| # | Rule | Path | Severity |" >> $GITHUB_STEP_SUMMARY
+              echo "|---|------|------|----------|" >> $GITHUB_STEP_SUMMARY
+
+              jq -r '.result.iacFindings[]? | select(.severity == "HIGH" or .severity == "CRITICAL") | "\(.ruleName)|\(.filePath):\(.lineNumber // "")|\(.severity)"' iac-results.json 2>/dev/null | \
+                sort -t'|' -k3 -r | \
+                nl -w1 -s'|' | while IFS='|' read -r num rule path severity; do
+                  echo "| ${num} | ${rule} | \`${path}\` | ${severity} |" >> $GITHUB_STEP_SUMMARY
+                done
+              echo "" >> $GITHUB_STEP_SUMMARY
+            elif [ "${IAC_FINDINGS}" -gt 0 ]; then
+              echo "✅ ${IAC_FINDINGS} finding(s) detected — all below HIGH severity threshold." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "✅ No misconfigurations found." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "⚠️ IaC scan results not available (JSON missing or invalid)." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi
+
+          # ═══════════════════════════════════════════════════════════
+          # Directory Scan — Source-Level Library Vulnerabilities
+          # ═══════════════════════════════════════════════════════════
+          echo "### Directory Scan (Source-Level Library Vulnerabilities)" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ -f "dir-results.json" ] && jq empty dir-results.json 2>/dev/null; then
+            DIR_VULN_TOTAL=$(jq -r '[.result.libraries[]?.vulnerabilities[]?] | length' dir-results.json 2>/dev/null || echo "0")
+
+            if [ "${DIR_VULN_TOTAL}" -gt 0 ]; then
+              DIR_CRITICAL=$(jq -r '[.result.libraries[]?.vulnerabilities[]? | select(.severity == "CRITICAL")] | length' dir-results.json 2>/dev/null || echo "0")
+              DIR_HIGH=$(jq -r '[.result.libraries[]?.vulnerabilities[]? | select(.severity == "HIGH")] | length' dir-results.json 2>/dev/null || echo "0")
+              DIR_MEDIUM=$(jq -r '[.result.libraries[]?.vulnerabilities[]? | select(.severity == "MEDIUM")] | length' dir-results.json 2>/dev/null || echo "0")
+              DIR_LOW=$(jq -r '[.result.libraries[]?.vulnerabilities[]? | select(.severity == "LOW" or .severity == "INFO")] | length' dir-results.json 2>/dev/null || echo "0")
+
+              echo "**Found:** ${DIR_VULN_TOTAL} vulnerabilities (${DIR_CRITICAL} Critical, ${DIR_HIGH} High, ${DIR_MEDIUM} Medium, ${DIR_LOW} Low/Info)" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+
+              # Show Critical + High + Medium in the table
+              SHOW_VULNS=$(jq -r '[.result.libraries[]?.vulnerabilities[]? | select(.severity == "CRITICAL" or .severity == "HIGH" or .severity == "MEDIUM")] | length' dir-results.json 2>/dev/null || echo "0")
+
+              if [ "${SHOW_VULNS}" -gt 0 ]; then
+                echo "| # | Package | CVE | Severity | Version | Fix Version | Path |" >> $GITHUB_STEP_SUMMARY
+                echo "|---|---------|-----|----------|---------|-------------|------|" >> $GITHUB_STEP_SUMMARY
+
+                jq -r '.result.libraries[]? | select(.vulnerabilities != null) | . as $lib | .vulnerabilities[]? | select(.severity == "CRITICAL" or .severity == "HIGH" or .severity == "MEDIUM") | "\($lib.name)|\(.name)|\(.severity)|\($lib.version)|\(.fixedVersion // "No fix available")|\($lib.path // "/go.mod")"' dir-results.json 2>/dev/null | \
+                  sort -t'|' -k3r | \
+                  nl -w1 -s'|' | while IFS='|' read -r num pkg cve severity version fix path; do
+                    echo "| ${num} | ${pkg} | ${cve} | ${severity} | ${version} | ${fix} | \`${path}\` |" >> $GITHUB_STEP_SUMMARY
+                  done
+
+                echo "" >> $GITHUB_STEP_SUMMARY
+              fi
+
+              if [ "${DIR_LOW}" -gt 0 ]; then
+                echo "> ℹ️ ${DIR_LOW} Low/Info severity finding(s) omitted from table." >> $GITHUB_STEP_SUMMARY
+                echo "" >> $GITHUB_STEP_SUMMARY
+              fi
+
+              echo "> **Note:** These are source-level findings from \`go.mod\` declarations. Check the **Docker Image Scan** job to confirm which vulnerabilities are actually compiled into the production binary." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            else
+              echo "✅ No library vulnerabilities found in source files." >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
+
+            # Secrets findings from directory scan
+            DIR_SECRETS=$(jq -r '[.result.secrets[]?] | length' dir-results.json 2>/dev/null || echo "0")
+            if [ "${DIR_SECRETS}" -gt 0 ]; then
+              echo "### ⚠️ Secrets Detection" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "**${DIR_SECRETS} secret(s) detected in source files.**" >> $GITHUB_STEP_SUMMARY
+              echo "" >> $GITHUB_STEP_SUMMARY
+              echo "| # | Type | Path | Description |" >> $GITHUB_STEP_SUMMARY
+              echo "|---|------|------|-------------|" >> $GITHUB_STEP_SUMMARY
+              jq -r '.result.secrets[]? | "\(.type // "Unknown")|\(.path // "N/A")|\(.description // "Secret detected")"' dir-results.json 2>/dev/null | \
+                nl -w1 -s'|' | while IFS='|' read -r num type path desc; do
+                  echo "| ${num} | ${type} | \`${path}\` | ${desc} |" >> $GITHUB_STEP_SUMMARY
+                done
+              echo "" >> $GITHUB_STEP_SUMMARY
+            fi
+          else
+            echo "⚠️ Directory scan results not available (JSON missing or invalid)." >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+          fi

--- a/.github/workflows/wiz-iac-scan-reusable.yaml
+++ b/.github/workflows/wiz-iac-scan-reusable.yaml
@@ -106,13 +106,13 @@ jobs:
             if [ "${IAC_HIGH}" -gt 0 ]; then
               echo "**${IAC_HIGH} High/Critical misconfiguration(s) found** (${IAC_FINDINGS} total findings)" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
-              echo "| # | Rule | Path | Severity |" >> $GITHUB_STEP_SUMMARY
-              echo "|---|------|------|----------|" >> $GITHUB_STEP_SUMMARY
+              echo "| Rule | Location | Severity |" >> $GITHUB_STEP_SUMMARY
+              echo "|------|----------|----------|" >> $GITHUB_STEP_SUMMARY
 
               jq -r '.result.iacFindings[]? | select(.severity == "HIGH" or .severity == "CRITICAL") | "\(.ruleName)|\(.filePath):\(.lineNumber // "")|\(.severity)"' iac-results.json 2>/dev/null | \
                 sort -t'|' -k3 -r | \
-                nl -w1 -s'|' | while IFS='|' read -r num rule path severity; do
-                  echo "| ${num} | ${rule} | \`${path}\` | ${severity} |" >> $GITHUB_STEP_SUMMARY
+                while IFS='|' read -r rule location severity; do
+                  echo "| ${rule} | \`${location}\` | ${severity} |" >> $GITHUB_STEP_SUMMARY
                 done
               echo "" >> $GITHUB_STEP_SUMMARY
             elif [ "${IAC_FINDINGS}" -gt 0 ]; then
@@ -149,13 +149,13 @@ jobs:
               SHOW_VULNS=$(jq -r '[.result.libraries[]?.vulnerabilities[]? | select(.severity == "CRITICAL" or .severity == "HIGH" or .severity == "MEDIUM")] | length' dir-results.json 2>/dev/null || echo "0")
 
               if [ "${SHOW_VULNS}" -gt 0 ]; then
-                echo "| # | Package | CVE | Severity | Version | Fix Version | Path |" >> $GITHUB_STEP_SUMMARY
-                echo "|---|---------|-----|----------|---------|-------------|------|" >> $GITHUB_STEP_SUMMARY
+                echo "| Package | Version | Location | CVE | Severity | Fix Available |" >> $GITHUB_STEP_SUMMARY
+                echo "|---------|---------|----------|-----|----------|---------------|" >> $GITHUB_STEP_SUMMARY
 
-                jq -r '.result.libraries[]? | select(.vulnerabilities != null) | . as $lib | .vulnerabilities[]? | select(.severity == "CRITICAL" or .severity == "HIGH" or .severity == "MEDIUM") | "\($lib.name)|\(.name)|\(.severity)|\($lib.version)|\(.fixedVersion // "No fix available")|\($lib.path // "/go.mod")"' dir-results.json 2>/dev/null | \
-                  sort -t'|' -k3r | \
-                  nl -w1 -s'|' | while IFS='|' read -r num pkg cve severity version fix path; do
-                    echo "| ${num} | ${pkg} | ${cve} | ${severity} | ${version} | ${fix} | \`${path}\` |" >> $GITHUB_STEP_SUMMARY
+                jq -r '.result.libraries[]? | select(.vulnerabilities != null) | . as $lib | .vulnerabilities[]? | select(.severity == "CRITICAL" or .severity == "HIGH" or .severity == "MEDIUM") | "\($lib.name)|\($lib.version)|\($lib.path // "/go.mod")|\(.name)|\(.severity)|\(.fixedVersion // "No fix available")"' dir-results.json 2>/dev/null | \
+                  sort -t'|' -k5r | \
+                  while IFS='|' read -r pkg version location cve severity fix; do
+                    echo "| ${pkg} | ${version} | \`${location}\` | ${cve} | ${severity} | ${fix} |" >> $GITHUB_STEP_SUMMARY
                   done
 
                 echo "" >> $GITHUB_STEP_SUMMARY
@@ -180,11 +180,11 @@ jobs:
               echo "" >> $GITHUB_STEP_SUMMARY
               echo "**${DIR_SECRETS} secret(s) detected in source files.**" >> $GITHUB_STEP_SUMMARY
               echo "" >> $GITHUB_STEP_SUMMARY
-              echo "| # | Type | Path | Description |" >> $GITHUB_STEP_SUMMARY
-              echo "|---|------|------|-------------|" >> $GITHUB_STEP_SUMMARY
+              echo "| Type | Location | Description |" >> $GITHUB_STEP_SUMMARY
+              echo "|------|----------|-------------|" >> $GITHUB_STEP_SUMMARY
               jq -r '.result.secrets[]? | "\(.type // "Unknown")|\(.path // "N/A")|\(.description // "Secret detected")"' dir-results.json 2>/dev/null | \
-                nl -w1 -s'|' | while IFS='|' read -r num type path desc; do
-                  echo "| ${num} | ${type} | \`${path}\` | ${desc} |" >> $GITHUB_STEP_SUMMARY
+                while IFS='|' read -r type location desc; do
+                  echo "| ${type} | \`${location}\` | ${desc} |" >> $GITHUB_STEP_SUMMARY
                 done
               echo "" >> $GITHUB_STEP_SUMMARY
             fi


### PR DESCRIPTION
## Summary

Creates a shared reusable workflow (`wiz-iac-scan-reusable.yaml`) for Wiz IaC & Directory scanning that all repos can call. This replaces the inline `iac-and-dir-scan` jobs that only showed misleading pass/fail messages in the Actions Summary.

### Problem

The existing inline IaC & Directory Scan job checks `steps.iac-scan.outcome == "success"` to determine if findings exist. In AUDIT/WARN mode, Wiz exits 0 even when findings are present — so the summary **always** says "No misconfigurations found" regardless of actual results. Library vulnerabilities from `go.mod` are completely invisible in the summary.

### Solution

This reusable workflow parses the Wiz JSON output and writes detailed tables to `$GITHUB_STEP_SUMMARY`, covering all three finding categories from `wizcli dir scan`:

1. **IaC Misconfigurations** — Dockerfile/Helm/K8s issues (HIGH+ shown in table)
2. **Library Vulnerabilities** — CVEs from `go.mod`/`package.json` (Critical/High/Medium in table)
3. **Secrets & Sensitive Data** — hardcoded keys/tokens (explicit status always shown)

### Features

- **Secret validation step** — fails fast with clear `::error::` if WIZ_CLIENT_ID/SECRET not configured
- **Detailed vulnerability tables** — aligned with existing Docker scan workflow (`Package | Version | Location | CVE | Severity | Fix Available`)
- **Explicit clean-state messages** — always shows status for both library vulns and secrets (no silent omissions)
- **Overall Result section** — concluding verdict with dynamic recommended actions
- **Configurable inputs** — `scan-path`, `iac-types`, `scan-timeout-minutes`
- **Artifact upload** — JSON results retained for 90 days

### Actions Summary Output Structure

```
## IaC & Directory Scan Results

### IaC Scan (Dockerfile, Helm, Kubernetes Misconfigurations)
  → table or ✅ message

### Directory Scan (Source-Level Libraries, Secrets & Sensitive Data)
  → library vuln table or ✅ message
  → secrets table or ✅ "No secrets or sensitive data found."

---
### Overall Result (verdict + recommended actions)
```

### Usage

```yaml
  iac-and-dir-scan:
    name: IaC & Directory Scan
    uses: Infoblox-CTO/.github/.github/workflows/wiz-iac-scan-reusable.yaml@main
    secrets:
      WIZ_CLIENT_ID: ${{ secrets.WIZ_CLIENT_ID }}
      WIZ_CLIENT_SECRET: ${{ secrets.WIZ_CLIENT_SECRET }}
    with:
      iac-types: 'Dockerfile,Kubernetes'
```

### Alignment with Existing Docker Scan Workflow

Follows the same patterns as `wiz-security-scan-reusable.yaml`:
- Same Wiz CLI install/auth steps
- Same artifact naming convention (`wiz-*-results-${{ github.sha }}`)
- Same table column naming (`Location`, `Fix Available`)
- Same `continue-on-error: true` for AUDIT mode scans
- Same 90-day artifact retention

### Pilot

First consumer: `atlas-onprem-platform-firewall` ([PR #125](https://github.com/Infoblox-CTO/atlas-onprem-platform-firewall/pull/125))