### PR TITLE
feat: add DockerHub credentials to wiz-security-scan-reusable workflow

### DIFF
--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -69,6 +69,12 @@ on:
       HARBOR_SERVICES_PROD_PASSWORD:
         required: true
         description: 'Harbor registry password for pulling base images'
+      DOCKERHUB_USERNAME:
+        required: false
+        description: 'DockerHub username for pulling base images (prevents rate limiting)'
+      DOCKERHUB_PASSWORD:
+        required: false
+        description: 'DockerHub password/token for pulling base images'
 
 jobs:
   wiz-scan:
@@ -157,6 +163,13 @@ jobs:
           registry: harbor.services.sdp.infoblox.com
           username: ${{ secrets.HARBOR_SERVICES_PROD_USERNAME }}
           password: ${{ secrets.HARBOR_SERVICES_PROD_PASSWORD }}
+      
+      - name: Login to Docker Hub
+        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
       
       - name: Build Docker image
         id: build

--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -53,6 +53,11 @@ on:
         required: false
         type: boolean
         default: false
+      enable-dockerhub-login:
+        description: 'Login to DockerHub before build to avoid rate limiting when pulling base images (golang, alpine, node, etc.)'
+        required: false
+        type: boolean
+        default: false
     secrets:
       GITPAT:
         required: true
@@ -165,7 +170,7 @@ jobs:
           password: ${{ secrets.HARBOR_SERVICES_PROD_PASSWORD }}
       
       - name: Login to Docker Hub
-        if: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+        if: ${{ inputs.enable-dockerhub-login }}
         uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}


### PR DESCRIPTION
Add DockerHub username and password secrets to enable pulling base images from DockerHub without rate limiting.

This change:
- Adds DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD to the secrets section (optional, required: false)
- Adds a 'Login to Docker Hub' step using docker/login-action@v3
- Placed after Harbor login and before docker build step
- Conditional check ensures it only runs if DOCKERHUB_USERNAME is provided

Fixes:
- atlas.bootstrap.service PR #1410 - Docker Image Scan failures
- ngp.onprem.logger PR #213 - Docker Image Scan failures

Both repositories pull base images from DockerHub (fluent/fluentd, golang, node, etc.) that require authentication to avoid rate limiting.

After merge, affected repos need to:
1. Add DOCKERHUB_USERNAME and DOCKERHUB_PASSWORD to their GitHub organization secrets
2. Trigger empty commits on their failing PRs to pick up the updated reusable workflow