### PR TITLE
fix: export GITPAT env var in Build Docker image step

### DIFF
--- a/.github/workflows/wiz-security-scan-reusable.yaml
+++ b/.github/workflows/wiz-security-scan-reusable.yaml
@@ -179,6 +179,8 @@ jobs:
       - name: Build Docker image
         id: build
         continue-on-error: true
+        env:
+          GITPAT: ${{ secrets.GITPAT }}
         run: |
           # Determine Dockerfile path
           if [ -n "${{ inputs.dockerfile-path }}" ]; then


### PR DESCRIPTION
## Problem

The `Build Docker image` step in `wiz-security-scan-reusable.yaml` does not expose `GITPAT` as a shell environment variable. This means passing `docker-build-secrets: "id=github_pat,env=GITPAT"` from a caller workflow has no effect — Docker can't find the `GITPAT` env var at build time.

## Fix

Add `env: GITPAT: ${{ secrets.GITPAT }}` to the Build Docker image step.

## Impact

Enables callers to pass Docker BuildKit secrets sourced from GITPAT (e.g. Dockerfiles that use `--mount=type=secret,id=github_pat`). No behaviour change for callers that don't set `docker-build-secrets`.